### PR TITLE
feat(config): track the current ConfigStore file

### DIFF
--- a/src/config/config_store.cpp
+++ b/src/config/config_store.cpp
@@ -40,10 +40,11 @@ bool vkShade::ConfigStore::load(std::filesystem::path filePath)
         return false;
     }
 
+    m_currentFile = filePath;
     return true;
 }
 
-bool vkShade::ConfigStore::save(std::filesystem::path filePath) const
+bool vkShade::ConfigStore::save(std::filesystem::path filePath)
 {
     std::ofstream file(filePath);
     if (!file.is_open())
@@ -99,6 +100,15 @@ bool vkShade::ConfigStore::save(std::filesystem::path filePath) const
             file << "\n";
     }
 
+    m_currentFile = filePath;
     spdlog::trace("Saved configuration to: {}", filePath.string());
     return true;
+}
+
+bool vkShade::ConfigStore::save()
+{
+    if (!m_currentFile.empty())
+        return this->save(m_currentFile);
+
+    return false;
 }

--- a/src/config/config_store.hpp
+++ b/src/config/config_store.hpp
@@ -15,7 +15,8 @@ namespace vkShade
     {
     public:
         bool load(std::filesystem::path filePath);
-        bool save(std::filesystem::path filePath) const;
+        bool save(std::filesystem::path filePath);  // Save As
+        bool save();  // Save currently open file
 
         // Typed getter
         template<typename T>
@@ -71,6 +72,7 @@ namespace vkShade
         ConfigParser   m_parser;
         ConfigObserver m_observer;
 
+        std::filesystem::path m_currentFile;
         std::unordered_map<std::string, std::string> m_config;
     };
 } // namespace vkShade

--- a/tests/config_store_tests.cpp
+++ b/tests/config_store_tests.cpp
@@ -371,3 +371,46 @@ TEST_CASE("ConfigStore: Load with string list", "[config][manager]")
     REQUIRE((*maps)[1] == "map2");
     REQUIRE((*maps)[2] == "map3");
 }
+
+TEST_CASE("ConfigStore: save() with no current file returns false", "[config][manager]")
+{
+    ConfigStore config;
+    config.set("test", "key", std::string("value"));
+
+    REQUIRE(config.save() == false);
+}
+
+TEST_CASE("ConfigStore: load sets current file for subsequent save()", "[config][manager]")
+{
+    TempConfigFile tempFile("test_currentfile.ini");
+    tempFile.write(
+        "[graphics]\n"
+        "width = 1920\n"
+    );
+
+    ConfigStore config;
+    REQUIRE(config.load(tempFile.path()) == true);
+
+    config.set("graphics", "width", 2560);
+    REQUIRE(config.save() == true);
+
+    ConfigStore config2;
+    config2.load(tempFile.path());
+    REQUIRE(*config2.get<int32_t>("graphics", "width") == 2560);
+}
+
+TEST_CASE("ConfigStore: explicit save() path sets current file", "[config][manager]")
+{
+    TempConfigFile tempFile("test_setcurrentfile.ini");
+    ConfigStore config;
+    config.set("test", "key", std::string("value"));
+
+    REQUIRE(config.save(tempFile.path()) == true);
+
+    config.set("test", "key", std::string("updated"));
+    REQUIRE(config.save() == true);
+
+    ConfigStore config2;
+    config2.load(tempFile.path());
+    REQUIRE(*config2.get<std::string>("test", "key") == "updated");
+}


### PR DESCRIPTION
- Adds m_currentFile member to track current config file
- Adds save() method to save current file (as opposed to save as)
- Adds new ConfigStore tests to confirm functionality