### PR TITLE
fix(input): don't unref XKB in Xlib backend destructor

### DIFF
--- a/src/input/input_backend_wayland.cpp
+++ b/src/input/input_backend_wayland.cpp
@@ -14,7 +14,6 @@ vkShade::InputBackendWayland::InputBackendWayland(wl_display* waylandDisplay)
 {
     // Set up input
     m_display = waylandDisplay;
-    m_xkbContext = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     wl_registry* reg = wl_display_get_registry(m_display);
     wl_registry_add_listener(reg, &reg_listener, this);     // Pass 'this' as void* in callbacks
     wl_display_roundtrip(m_display);  // Get globals

--- a/src/input/input_backend_xlib.cpp
+++ b/src/input/input_backend_xlib.cpp
@@ -22,16 +22,6 @@ vkShade::InputBackendXlib::InputBackendXlib(Display* display, Window window)
     std::memset(m_previousKeymap, 0, sizeof(m_previousKeymap));
 }
 
-vkShade::InputBackendXlib::~InputBackendXlib()
-{
-    if (m_xkbState)
-        xkb_state_unref(m_xkbState);
-    if (m_xkbKeymap)
-        xkb_keymap_unref(m_xkbKeymap);
-    if (m_xkbContext)
-        xkb_context_unref(m_xkbContext);
-}
-
 void vkShade::InputBackendXlib::process_events()
 {
     if (!m_display || !m_xkbState)

--- a/src/input/input_backend_xlib.hpp
+++ b/src/input/input_backend_xlib.hpp
@@ -11,7 +11,6 @@ namespace vkShade
     {
     public:
         InputBackendXlib(Display* display, Window window);
-        ~InputBackendXlib();
 
         void process_events() override;
 


### PR DESCRIPTION
Fixes a crash on layer shutdown