### PR TITLE
fix(hooks): initialize command buffer dispatch pointers

### DIFF
--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -67,7 +67,7 @@ vkShade::GuiManager::GuiManager(VulkanDevice deviceContext, VkFormat swapchainFo
         auto& instance = get_instance_from_handle(ctx->instance);
 
         // Try the device table first (most functions are device-level)
-        PFN_vkVoidFunction func = (PFN_vkVoidFunction)ctx->dispatch.GetDeviceProcAddr(ctx->handle, function_name);
+        PFN_vkVoidFunction func = vkShade_GetDeviceProcAddr(ctx->handle, function_name);
         if (func)
         {
             spdlog::trace("[ImGui] Loaded {} from device table:  {}", function_name, (void*)func);
@@ -75,7 +75,7 @@ vkShade::GuiManager::GuiManager(VulkanDevice deviceContext, VkFormat swapchainFo
         }
 
         // Fall back to the instance table
-        func = (PFN_vkVoidFunction)instance.dispatch.GetInstanceProcAddr(instance.handle, function_name);
+        func = vkShade_GetInstanceProcAddr(instance.handle, function_name);
         if (func)
         {
             spdlog::trace("[ImGui] Loaded {} from instance table: {}", function_name, (void*)func);

--- a/src/hooks/hooks.hpp
+++ b/src/hooks/hooks.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <assert.h>
-#include <mutex>
+#include <shared_mutex>
 #include <unordered_map>
 
 #include <vk_mem_alloc.h>
@@ -63,9 +63,8 @@ inline VulkanDevice& get_device_from_handle(const void* handle)
     return it->second;
 }
 
-// Single global lock, for simplicity
-// Only lock when WRITING (on create and destroy)
-extern std::mutex global_lock;
+// Reader/writer lock for concurrent read access to bookkeeping maps.
+extern std::shared_mutex g_globalLock;
 
 // Make entrypoints C-linkable
 extern "C" PFN_vkVoidFunction VKAPI_CALL vkShade_GetDeviceProcAddr(VkDevice device, const char* pName);

--- a/src/hooks/hooks.hpp
+++ b/src/hooks/hooks.hpp
@@ -82,3 +82,8 @@ void     VKAPI_CALL vkShade_DestroyDevice(VkDevice device, const VkAllocationCal
 VkResult VKAPI_CALL vkShade_CreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain);
 void     VKAPI_CALL vkShade_DestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks* pAllocator);
 VkResult VKAPI_CALL vkShade_QueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo);
+
+// Command Buffer hooks
+VkResult VKAPI_CALL vkShade_AllocateCommandBuffers(VkDevice                           device,
+                                                   const VkCommandBufferAllocateInfo* pAllocateInfo,
+                                                   VkCommandBuffer*                   pCommandBuffers);

--- a/src/hooks/hooks_device.cpp
+++ b/src/hooks/hooks_device.cpp
@@ -232,3 +232,27 @@ VK_LAYER_EXPORT void VKAPI_CALL vkShade_DestroyDevice(VkDevice device, const VkA
     // Remove the VulkanDevice from layer's bookkeeping
     g_vulkanDevices.erase(dispatch_key_from_handle(device));
 }
+
+VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_AllocateCommandBuffers(VkDevice                           device,
+                                                                   const VkCommandBufferAllocateInfo* pAllocateInfo,
+                                                                   VkCommandBuffer*                   pCommandBuffers)
+{
+    auto& thisDevice = get_device_from_handle(device);
+    VkResult result = thisDevice.dispatch.AllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers);
+
+    // Command buffers are dispatchable objects — the loader normally fixes up the dispatch table
+    // pointer in the handle, but only when the call goes through the loader trampoline. When a
+    // layer allocates command buffers internally via its own dispatch table, the trampoline is
+    // bypassed and the fixup never happens. We do it manually here so the validation layer can
+    // look up the device from any command buffer handle, regardless of who allocated it.
+    // NOTE: This is required for validation layers to work.
+    if (result == VK_SUCCESS)
+    {
+        for (uint32_t i = 0; i < pAllocateInfo->commandBufferCount; i++)
+        {
+            *reinterpret_cast<void**>(pCommandBuffers[i]) = *reinterpret_cast<void**>(device);
+        }
+    }
+
+    return result;
+}

--- a/src/hooks/hooks_device.cpp
+++ b/src/hooks/hooks_device.cpp
@@ -197,7 +197,8 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
 
     // Store device data
     {
-        std::lock_guard<std::mutex> lock(global_lock);
+        // Acquire a writer lock
+        std::unique_lock lock(g_globalLock);
         g_vulkanDevices.emplace(dispatch_key_from_handle(*pDevice), thisDevice);
     }
 
@@ -213,7 +214,7 @@ VK_LAYER_EXPORT void VKAPI_CALL vkShade_DestroyDevice(VkDevice device, const VkA
     spdlog::trace("Intercepted VkDestroyDevice");
 
     // Lock here to prevent race conditions.
-    std::lock_guard<std::mutex> lock(global_lock);
+    std::unique_lock lock(g_globalLock);
 
     if (!device)
         return;

--- a/src/hooks/hooks_entrypoints.cpp
+++ b/src/hooks/hooks_entrypoints.cpp
@@ -10,14 +10,13 @@
 
 // Layer book-keeping information
 // These are only modified during create/destroy
-// NOTE: These are declared in `vulkan_hooks.hpp`
+// NOTE: These are declared in `hooks.hpp`
 std::unordered_map<void*, VulkanInstance> g_vulkanInstances;
 std::unordered_map<void*, VulkanDevice>   g_vulkanDevices;
 
-// Single global lock, for simplicity
-// Only lock when WRITING (on create and destroy)
-// NOTE: This is declared in `vulkan_hooks.hpp`
-std::mutex global_lock;
+// Reader/writer lock for concurrent read access to bookkeeping maps.
+// NOTE: This is declared in `hooks.hpp`
+std::shared_mutex g_globalLock;
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // GetProcAddr functions, the entry points of the layer.
@@ -42,9 +41,9 @@ VK_LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL vkShade_GetDeviceProcAddr(VkDevice
 
     GETPROCADDR(AllocateCommandBuffers);
 
+    // Acquire a reader lock
     {
-        std::lock_guard<std::mutex> lock(global_lock);
-
+        std::shared_lock lock(g_globalLock);
         auto& thisDevice = get_device_from_handle(device);
         return reinterpret_cast<PFN_vkVoidFunction>(thisDevice.dispatch.GetDeviceProcAddr(device, pName));
     }
@@ -68,9 +67,9 @@ VK_LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL vkShade_GetInstanceProcAddr(VkInst
     GETPROCADDR(CreateXcbSurfaceKHR);
     GETPROCADDR(CreateXlibSurfaceKHR);
 
+    // Acquire a reader lock
     {
-        std::lock_guard<std::mutex> lock(global_lock);
-
+        std::shared_lock lock(g_globalLock);
         auto& thisInstance = get_instance_from_handle(instance);
         return reinterpret_cast<PFN_vkVoidFunction>(thisInstance.dispatch.GetInstanceProcAddr(instance, pName));
     }

--- a/src/hooks/hooks_entrypoints.cpp
+++ b/src/hooks/hooks_entrypoints.cpp
@@ -40,6 +40,8 @@ VK_LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL vkShade_GetDeviceProcAddr(VkDevice
     GETPROCADDR(DestroySwapchainKHR);
     GETPROCADDR(QueuePresentKHR);
 
+    GETPROCADDR(AllocateCommandBuffers);
+
     {
         std::lock_guard<std::mutex> lock(global_lock);
 

--- a/src/hooks/hooks_instance.cpp
+++ b/src/hooks/hooks_instance.cpp
@@ -117,7 +117,8 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateInstance(
 
     // Store instance data
     {
-        std::lock_guard<std::mutex> lock(global_lock);
+        // Acquire a writer lock
+        std::unique_lock lock(g_globalLock);
         g_vulkanInstances.emplace(dispatch_key_from_handle(*pInstance), thisInstance);
     }
 
@@ -129,7 +130,7 @@ VK_LAYER_EXPORT void VKAPI_CALL vkShade_DestroyInstance(VkInstance instance, con
     spdlog::trace("Intercepted VkDestroyInstance");
 
     // Lock here to prevent race conditions.
-    std::lock_guard<std::mutex> lock(global_lock);
+    std::unique_lock lock(g_globalLock);
 
     if (!instance)
         return;

--- a/src/vk/swapchain.cpp
+++ b/src/vk/swapchain.cpp
@@ -68,7 +68,9 @@ vkShade::VulkanSwapchain::VulkanSwapchain(VulkanDevice& device, VkSwapchainKHR s
         .commandBufferCount = 1,
     };
 
-    VK_CHECK(m_device.dispatch.AllocateCommandBuffers(m_device.handle, &allocInfo, &m_commandBuffer));
+    // NOTE: Command buffers are dispatchable types. Their creation must go through our
+    //  own hook, not the dispatch table, to ensure the dispatch pointer fixup runs.
+    VK_CHECK(vkShade_AllocateCommandBuffers(m_device.handle, &allocInfo, &m_commandBuffer));
 
     auto& config = vkShade::Locator<vkShade::ConfigManager>::get().app();
 


### PR DESCRIPTION
Command buffers are dispatchable objects. When allocated through the dispatch table directly, the loader trampoline is bypassed and the dispatch pointer is never fixed up, causing the validation layer to crash when looking up the device.

Hook vkAllocateCommandBuffers to fix up the dispatch pointer on all allocations, and route internal allocations through the hook rather than the dispatch table.

Fixes crash when using validation layers.

Also fixes a deadlock triggered by this PR, caused by unnecessary exclusive locking when reading from the instance dispatch map.