### PR TITLE
feat(*): add and bind a dummy depth image

### DIFF
--- a/src/vk/reshade_effect.cpp
+++ b/src/vk/reshade_effect.cpp
@@ -692,6 +692,7 @@ void vkShade::ReshadeEffect::reflect_descriptors()
 void vkShade::ReshadeEffect::reflect_images()
 {
     // Iterate and check for depth textures since we don't support them yet
+    bool warnedAboutDepth = false;
     for (const auto& pass : m_module->techniques[0].passes)
     {
         for (const auto& binding : pass.texture_bindings)
@@ -701,8 +702,11 @@ void vkShade::ReshadeEffect::reflect_images()
                 [&](const auto& t) { return t.unique_name == textureName; });
 
             // Warn about lack of proper depth support
-            if (texIt != m_module->textures.end() && texIt->semantic == "DEPTH")
+            if (!warnedAboutDepth && texIt != m_module->textures.end() && texIt->semantic == "DEPTH")
+            {
                 spdlog::warn("Effect may require depth buffer access, which is not yet supported.");
+                warnedAboutDepth = true;
+            }
         }
     }
 

--- a/src/vk/reshade_effect.cpp
+++ b/src/vk/reshade_effect.cpp
@@ -171,7 +171,7 @@ void vkShade::ReshadeEffect::apply(VkCommandBuffer cmd, VulkanImage& outputImage
     }
 }
 
-void vkShade::ReshadeEffect::bind_input(VkImageView colorView)
+void vkShade::ReshadeEffect::bind_input(VulkanImage& colorImage, VulkanImage& depthImage)
 {
     for (auto&& [pass, passInfo] : std::views::zip(m_passes, m_module->techniques[0].passes))
     {
@@ -183,13 +183,20 @@ void vkShade::ReshadeEffect::bind_input(VkImageView colorView)
             auto texIt = std::find_if(m_module->textures.begin(), m_module->textures.end(),
                 [&](const auto& t) { return t.unique_name == samplerInfo.texture_name; });
 
-            // Only handle semantic textures here (COLOR) // TODO: Depth
-            if (texIt == m_module->textures.end() || texIt->semantic != "COLOR")
+            if (texIt == m_module->textures.end())
                 continue;
+
+            VkImageView imageView;
+            if (texIt->semantic == "COLOR")
+                imageView = colorImage.image_view();
+            else if (texIt->semantic == "DEPTH")
+                imageView = depthImage.image_view();
+            else
+                continue;  // Skip other textures (we only bind COLOR and DEPTH here)
 
             VkDescriptorImageInfo imageInfo = {
                 .sampler = sampler->handle(),
-                .imageView = colorView,
+                .imageView = imageView,
                 .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
             };
 
@@ -693,9 +700,9 @@ void vkShade::ReshadeEffect::reflect_images()
             auto texIt = std::find_if(m_module->textures.begin(), m_module->textures.end(),
                 [&](const auto& t) { return t.unique_name == textureName; });
 
-            // Refuse to load the effect
+            // Warn about lack of proper depth support
             if (texIt != m_module->textures.end() && texIt->semantic == "DEPTH")
-                throw std::runtime_error("Effect requires depth buffer access, which is not yet supported.");
+                spdlog::warn("Effect may require depth buffer access, which is not yet supported.");
         }
     }
 

--- a/src/vk/reshade_effect.hpp
+++ b/src/vk/reshade_effect.hpp
@@ -44,7 +44,7 @@ namespace vkShade
         };
 
         void apply(VkCommandBuffer cmd, VulkanImage& outputImage);
-        void bind_input(VkImageView colorView);
+        void bind_input(VulkanImage& colorImage, VulkanImage& depthImage);
         void update();
 
         template <class T>

--- a/src/vk/swapchain.cpp
+++ b/src/vk/swapchain.cpp
@@ -43,6 +43,13 @@ vkShade::VulkanSwapchain::VulkanSwapchain(VulkanDevice& device, VkSwapchainKHR s
     m_pingPongA = std::shared_ptr<VulkanImage>(new VulkanImage(m_device, m_extent, m_format, drawImageUsages));
     m_pingPongB = std::shared_ptr<VulkanImage>(new VulkanImage(m_device, m_extent, m_format, drawImageUsages));
 
+    // Create a dummy depth image.
+	VkImageUsageFlags depthImageUsages {};
+	depthImageUsages |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+	depthImageUsages |= VK_IMAGE_USAGE_SAMPLED_BIT;
+
+    m_depthDummy = std::make_unique<VulkanImage>(m_device, m_extent, VK_FORMAT_R32_SFLOAT, depthImageUsages);
+
     // Create command pool
     VkCommandPoolCreateInfo poolInfo = {
         .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
@@ -161,6 +168,14 @@ void vkShade::VulkanSwapchain::render(uint32_t imageIndex)
     swapchainImage->blit_to(m_commandBuffer, m_pingPongA->image());
     m_pingPongA->transition_layout(m_commandBuffer, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
+    // Clear our dummy depth image and transition to SHADER_READ_ONLY
+    m_depthDummy->transition_layout(m_commandBuffer, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    VkClearColorValue clearValue = { .float32 = { 1.0f, 0.0f, 0.0f, 0.0f } };
+    VkImageSubresourceRange range = vkinit::image_subresource_range(VK_IMAGE_ASPECT_COLOR_BIT);
+    m_device.dispatch.CmdClearColorImage(m_commandBuffer, m_depthDummy->image(),
+        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearValue, 1, &range);
+    m_depthDummy->transition_layout(m_commandBuffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
     // Render effects if enabled
     auto& input = vkShade::Locator<vkShade::InputManager>::get();
     static bool enabled = true;
@@ -183,8 +198,8 @@ void vkShade::VulkanSwapchain::render(uint32_t imageIndex)
             // Barrier: Ensure read image is ready to sample
             readImage->transition_layout(m_commandBuffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
-            // Bind the input (read) image
-            effect->bind_input(readImage->image_view());
+            // Bind the color and depth images
+            effect->bind_input(*readImage, *m_depthDummy);
 
             // Apply effect
             effect->apply(m_commandBuffer, *writeImage);

--- a/src/vk/swapchain.hpp
+++ b/src/vk/swapchain.hpp
@@ -33,6 +33,7 @@ namespace vkShade
         VkFormat m_format;
         VkExtent2D m_extent;
         std::vector<std::unique_ptr<VulkanImage>> m_images;
+        std::unique_ptr<VulkanImage> m_depthDummy;
 
         // Layer resources
         VkFence m_fence {VK_NULL_HANDLE};


### PR DESCRIPTION
Some effects may bind the depth buffer as a soft dependency, this allows those effects to load. A warning is displayed in the logs about incomplete depth support.