### PR TITLE
perf(build): actually set NDEBUG on release builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,5 @@
-project('vkShade', ['c', 'cpp'], version: files('VERSION'), default_options: ['c_std=c11', 'cpp_std=c++23'])
+project('vkShade', ['c', 'cpp'], version: files('VERSION'),
+  default_options: ['c_std=c11', 'cpp_std=c++23', 'b_ndebug=if-release'])
 
 cpp = meson.get_compiler('cpp')
 


### PR DESCRIPTION
Apparently Meson doesn't do this by default, because reasons.

CPU overhead is already negligible in vkShade, but nonetheless this should result in a performance boost (albeit probably imperceptible).