### PR TITLE
fix: handle recreated surfaces and internal render target extents

### DIFF
--- a/src/hooks/hooks_surface.cpp
+++ b/src/hooks/hooks_surface.cpp
@@ -16,9 +16,6 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateWaylandSurfaceKHR(VkInstance  
 {
     spdlog::trace("Intercepted VkCreateWaylandSurfaceKHR");
 
-    // Initialize InputManager
-    vkShade::Locator<vkShade::InputManager>::emplace<vkShade::InputBackendWayland>(pCreateInfo->display);
-
     auto& thisInstance = get_instance_from_handle(instance);
 
     // Get the function pointer manually since extensions aren't in the dispatch table
@@ -28,6 +25,13 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateWaylandSurfaceKHR(VkInstance  
     VkResult result = createWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     if (result == VK_SUCCESS)
     {
+        // The Wayland backend is scoped to wl_display rather than wl_surface,
+        // and its proxies keep callbacks pointing at the backend instance.
+        // TODO: Support replacing it if the display changes after all owned
+        // Wayland proxies have explicit, safe lifetime management.
+        if (!vkShade::Locator<vkShade::InputManager>::has())
+            vkShade::Locator<vkShade::InputManager>::emplace<vkShade::InputBackendWayland>(
+                pCreateInfo->display);
         spdlog::debug("Wayland surface created");
     }
 
@@ -42,11 +46,9 @@ VK_LAYER_EXPORT VkResult vkShade_CreateXcbSurfaceKHR(VkInstance                 
 {
     spdlog::trace("Intercepted VkCreateXcbSurfaceKHR");
 
-    // Initialize InputManager
     auto* xcbCreateInfo = reinterpret_cast<const VkXcbSurfaceCreateInfoKHR*>(pCreateInfo);
     xcb_connection_t* connection = xcbCreateInfo->connection;
     xcb_window_t window = xcbCreateInfo->window;
-    vkShade::Locator<vkShade::InputManager>::emplace<vkShade::InputBackendXcb>(connection, window);
 
     auto& thisInstance = get_instance_from_handle(instance);
 
@@ -57,6 +59,8 @@ VK_LAYER_EXPORT VkResult vkShade_CreateXcbSurfaceKHR(VkInstance                 
     VkResult result = createXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     if (result == VK_SUCCESS)
     {
+        vkShade::Locator<vkShade::InputManager>::reset();
+        vkShade::Locator<vkShade::InputManager>::emplace<vkShade::InputBackendXcb>(connection, window);
         spdlog::debug("X11 (XCB) surface created");
         spdlog::warn("XCB input is currently unsupported");
     }
@@ -71,11 +75,9 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateXlibSurfaceKHR(VkInstance     
 {
     spdlog::trace("Intercepted VkCreateXlibSurfaceKHR");
 
-    // Initialize InputManager
     auto* xlibCreateInfo = reinterpret_cast<const VkXlibSurfaceCreateInfoKHR*>(pCreateInfo);
     Window window = xlibCreateInfo->window;
     Display* display = xlibCreateInfo->dpy;
-    vkShade::Locator<vkShade::InputManager>::emplace<vkShade::InputBackendXlib>(display, window);
 
     auto& thisInstance = get_instance_from_handle(instance);
 
@@ -86,6 +88,8 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateXlibSurfaceKHR(VkInstance     
     VkResult result = createXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     if (result == VK_SUCCESS)
     {
+        vkShade::Locator<vkShade::InputManager>::reset();
+        vkShade::Locator<vkShade::InputManager>::emplace<vkShade::InputBackendXlib>(display, window);
         spdlog::debug("X11 (Xlib) surface created");
     }
 

--- a/src/vk/reshade_effect.cpp
+++ b/src/vk/reshade_effect.cpp
@@ -78,6 +78,10 @@ void vkShade::ReshadeEffect::apply(VkCommandBuffer cmd, VulkanImage& outputImage
         const VkClearValue clearValue = { .color = { .float32 = { 0.0f, 0.0f, 0.0f, 0.0f } } };
         const VkClearValue* clear = passInfo.clear_render_targets ? &clearValue : nullptr;
 
+        VkExtent2D attachmentExtent {
+            .width = outputImage.extent().width,
+            .height = outputImage.extent().height,
+        };
         std::vector<VkRenderingAttachmentInfo> colorAttachments;
         for (const auto& name : passInfo.render_target_names)
         {
@@ -85,6 +89,11 @@ void vkShade::ReshadeEffect::apply(VkCommandBuffer cmd, VulkanImage& outputImage
                 break;  // render_target_names are contiguous, empty means end
 
             auto* renderTarget = m_textures.at(name).get();
+            if (colorAttachments.empty())
+            {
+                attachmentExtent.width = renderTarget->extent().width;
+                attachmentExtent.height = renderTarget->extent().height;
+            }
             renderTarget->transition_layout(cmd, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
             colorAttachments.push_back(vkinit::rendering_attachment_info(renderTarget->image_view(),
                                                                          clear,
@@ -99,11 +108,18 @@ void vkShade::ReshadeEffect::apply(VkCommandBuffer cmd, VulkanImage& outputImage
                                                                          VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL));
         }
 
+        VkExtent2D passExtent {
+            .width = passInfo.viewport_width ? passInfo.viewport_width : attachmentExtent.width,
+            .height = passInfo.viewport_height ? passInfo.viewport_height : attachmentExtent.height,
+        };
+
         // Set up stencil attachment if there is one
         VkRenderingAttachmentInfo* stencilAttachment = nullptr;
         VkRenderingAttachmentInfo stencilAttachmentInfo;
 
-        if (passInfo.stencil_enable && m_stencilBuffer)
+        if (passInfo.stencil_enable && m_stencilBuffer
+            && passExtent.width == m_stencilBuffer->extent().width
+            && passExtent.height == m_stencilBuffer->extent().height)
         {
             m_stencilBuffer->transition_layout(cmd, VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL);
 
@@ -116,8 +132,8 @@ void vkShade::ReshadeEffect::apply(VkCommandBuffer cmd, VulkanImage& outputImage
         }
 
         // Begin render pass
-        VkExtent2D extent { .width = outputImage.extent().width, .height = outputImage.extent().height};
-        VkRenderingInfo renderingInfo = vkinit::rendering_info(extent, colorAttachments, nullptr, stencilAttachment);
+        VkRenderingInfo renderingInfo = vkinit::rendering_info(passExtent, colorAttachments,
+                                                               nullptr, stencilAttachment);
         m_device.dispatch.CmdBeginRendering(cmd, &renderingInfo);
 
         // Bind pipeline
@@ -127,8 +143,8 @@ void vkShade::ReshadeEffect::apply(VkCommandBuffer cmd, VulkanImage& outputImage
         VkViewport viewport = {
             .x = 0.0f,
             .y = 0.0f,
-            .width = (float)(passInfo.viewport_width ? passInfo.viewport_width : extent.width),
-            .height = (float)(passInfo.viewport_height ? passInfo.viewport_height : extent.height),
+            .width = static_cast<float>(passExtent.width),
+            .height = static_cast<float>(passExtent.height),
             .minDepth = 0.0f,
             .maxDepth = 1.0f,
         };
@@ -136,7 +152,7 @@ void vkShade::ReshadeEffect::apply(VkCommandBuffer cmd, VulkanImage& outputImage
 
         VkRect2D scissor = {
             .offset = {0, 0},
-            .extent = extent,
+            .extent = passExtent,
         };
         m_device.dispatch.CmdSetScissor(cmd, 0, 1, &scissor);
 


### PR DESCRIPTION
## Summary

This fixes two latent lifetime and rendering assumptions:

- Recreate the input backend after successful native surface creation, so it does not retain display or window handles belonging to an old surface.
- Derive dynamic rendering dimensions from the active effect attachment or the reflected pass viewport instead of always using the swapchain extent.
- Only attach the shared stencil buffer when its extent is compatible with the current pass.

## Surface and input-backend lifetime

Applications may recreate their native window and Vulkan surface when changing display modes, particularly when entering or leaving exclusive fullscreen.

vkShade currently initializes the input backend before forwarding the surface creation call. Since the service locator retains an existing backend, an X11 backend may subsequently remain associated with the window belonging to an old surface.

Input backends are now initialized only after native Vulkan surface creation succeeds. Existing XCB and Xlib backends are replaced at that point so their input state always refers to the current native window.

The Wayland backend is scoped to `wl_display` rather than an individual `wl_surface`, so it is retained across surface recreation. Replacing it is intentionally deferred until the registry, seat, keyboard, and pointer proxies have explicit lifetime management, since their callbacks currently retain a pointer to the backend instance.

This issue became visible while developing follow-up GUI mouse-capture support. That work gives the X11 input backends more state tied to the native window, making stale handles capable of causing failures during fullscreen transitions. The underlying lifetime mismatch already exists independently of that follow-up work.

The mouse-capture changes are intentionally not included in this PR. They are larger, have additional platform-specific behavior to resolve, and can be submitted separately on top of this lifecycle fix. Proper Wayland proxy and event-queue lifecycle management also remains separate follow-up work.

## Internal render-target extents

Effect passes may render into internal textures that are much smaller than the swapchain, including targets such as 1x1 or 256x256 textures.

The existing dynamic-rendering path always uses the output image extent for the render area and scissor. This may exceed the extent of an internal color attachment. The shared swapchain-sized stencil attachment may also be incompatible with such a pass.

This was exposed while implementing more complete ReShade texture and mipmap semantics, since those changes exercise small internal render targets more consistently. Again, the follow-up work did not introduce the extent mismatch; it only made an existing invalid assumption observable.

The pass now:

- derives its attachment extent from the first internal color target;
- falls back to the output image extent when rendering to the output;
- respects reflected viewport dimensions;
- uses the resulting extent for dynamic rendering, viewport, and scissor; and
- omits the shared stencil attachment when its dimensions do not match.

## Testing

- Both the standalone PR branch and the full follow-up queue build successfully with Meson/Ninja.
- The surface lifecycle path was exercised while testing fullscreen transitions in Euro Truck Simulator 2 under Proton.
- Small internal render targets were exercised with ReShade effects including EyeAdaption and Bloom.
- The project currently defines no automated tests.

The larger GUI input-capture and ReShade resource-semantics changes remain separate follow-up work.