### PR TITLE
fix(reshade): align runtime uniform semantics with ReShade

### DIFF
--- a/src/vk/reshade_effect.cpp
+++ b/src/vk/reshade_effect.cpp
@@ -800,40 +800,50 @@ void vkShade::ReshadeEffect::reflect_uniforms()
         {
             const auto& source = sourceIt->value.string_data;
 
-            if (source == "frametime")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::FrameTimeUniform>(uniform));
-            else if (source == "framecount")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::FrameCountUniform>(uniform));
-            else if (source == "date")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::DateUniform>(uniform));
-            else if (source == "timer")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::TimerUniform>(uniform));
-            else if (source == "pingpong")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::PingPongUniform>(uniform));
-            else if (source == "random")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::RandomUniform>(uniform));
-            else if (source == "key")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::KeyUniform>(uniform));
-            else if (source == "mousebutton")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::MouseButtonUniform>(uniform));
-            else if (source == "mousepoint")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::MousePointUniform>(uniform));
-            else if (source == "mousedelta")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::MouseDeltaUniform>(uniform));
-            else if (source == "mousewheel")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::MouseWheelUniform>(uniform));
-            else if (source == "bufready_depth")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::DepthUniform>(uniform));
-            else if (source == "overlay_open")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::OverlayOpenUniform>(uniform));
-            else if (source == "overlay_active")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::OverlayActiveUniform>(uniform));
-            else if (source == "overlay_hovered")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::OverlayHoveredUniform>(uniform));
-            else if (source == "screenshot")
-                m_builtinUniforms.push_back(std::make_unique<vkShade::ScreenshotUniform>(uniform));
+            if (reshade_uniform_uses_initializer(source))
+                sourceIt = uniform.annotations.end();
+            else
+            {
+                // ReShade clears all source uniforms, including unknown sources,
+                // rather than applying their shader initializer.
+                std::vector<std::byte> zero(uniform.size);
+                m_uniformBuffer->write(zero.data(), zero.size(), uniform.offset);
 
-            continue;  // Skip GUI reflection for built-in uniforms
+                if (source == "frametime")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::FrameTimeUniform>(uniform));
+                else if (source == "framecount")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::FrameCountUniform>(uniform));
+                else if (source == "date")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::DateUniform>(uniform));
+                else if (source == "timer")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::TimerUniform>(uniform));
+                else if (source == "pingpong")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::PingPongUniform>(uniform));
+                else if (source == "random")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::RandomUniform>(uniform));
+                else if (source == "key")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::KeyUniform>(uniform));
+                else if (source == "mousebutton")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::MouseButtonUniform>(uniform));
+                else if (source == "mousepoint")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::MousePointUniform>(uniform));
+                else if (source == "mousedelta")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::MouseDeltaUniform>(uniform));
+                else if (source == "mousewheel")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::MouseWheelUniform>(uniform));
+                else if (source == "bufready_depth")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::DepthUniform>(uniform));
+                else if (source == "overlay_open")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::OverlayOpenUniform>(uniform));
+                else if (source == "overlay_active")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::OverlayActiveUniform>(uniform));
+                else if (source == "overlay_hovered")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::OverlayHoveredUniform>(uniform));
+                else if (source == "screenshot")
+                    m_builtinUniforms.push_back(std::make_unique<vkShade::ScreenshotUniform>(uniform));
+
+                continue;  // Skip GUI reflection for source uniforms
+            }
         }
 
         // Generic/GUI uniform

--- a/src/vk/reshade_effect.cpp
+++ b/src/vk/reshade_effect.cpp
@@ -853,10 +853,10 @@ void vkShade::ReshadeEffect::reflect_uniforms()
     }
 }
 
-void vkShade::ReshadeEffect::update()
+void vkShade::ReshadeEffect::update(const ReshadeFrameState& frame)
 {
     for (auto& uniform : m_builtinUniforms)
     {
-        uniform->update(*m_uniformBuffer);
+        uniform->update(*m_uniformBuffer, frame);
     }
 }

--- a/src/vk/reshade_effect.hpp
+++ b/src/vk/reshade_effect.hpp
@@ -46,7 +46,7 @@ namespace vkShade
 
         void apply(VkCommandBuffer cmd, VulkanImage& outputImage);
         void bind_input(VulkanImage& colorImage, VulkanImage& depthImage);
-        void update();
+        void update(const ReshadeFrameState& frame);
 
         template <class T>
         std::expected<T, Error> get_uniform(const std::string& name)

--- a/src/vk/reshade_runtime.hpp
+++ b/src/vk/reshade_runtime.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <chrono>
+
+namespace vkShade
+{
+    inline float reshade_frame_time(std::chrono::steady_clock::duration duration)
+    {
+        return std::chrono::duration<float, std::milli>(duration).count();
+    }
+}

--- a/src/vk/reshade_runtime.hpp
+++ b/src/vk/reshade_runtime.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
+#include <limits>
 
 namespace vkShade
 {
@@ -8,4 +10,42 @@ namespace vkShade
     {
         return std::chrono::duration<float, std::milli>(duration).count();
     }
+
+    struct ReshadeFrameState
+    {
+        float frame_time {0.0f};
+        uint32_t frame_count {0};
+        float timer {0.0f};
+    };
+
+    class ReshadeRuntime
+    {
+    public:
+        using Clock = std::chrono::steady_clock;
+
+        explicit ReshadeRuntime(Clock::time_point start = Clock::now())
+            : m_start(start), m_lastFrame(start)
+        {
+        }
+
+        const ReshadeFrameState& begin_frame(Clock::time_point now = Clock::now())
+        {
+            m_currentFrame.frame_time = reshade_frame_time(now - m_lastFrame);
+            m_currentFrame.frame_count = static_cast<uint32_t>(
+                m_frameCount % std::numeric_limits<uint32_t>::max());
+            m_currentFrame.timer = reshade_frame_time(now - m_start);
+
+            m_lastFrame = now;
+            ++m_frameCount;
+            return m_currentFrame;
+        }
+
+        const ReshadeFrameState& current_frame() const { return m_currentFrame; }
+
+    private:
+        Clock::time_point m_start;
+        Clock::time_point m_lastFrame;
+        uint64_t m_frameCount {0};
+        ReshadeFrameState m_currentFrame;
+    };
 }

--- a/src/vk/reshade_runtime.hpp
+++ b/src/vk/reshade_runtime.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <algorithm>
+#include <array>
 #include <chrono>
+#include <cmath>
+#include <cstdlib>
 #include <cstdint>
 #include <limits>
+#include <string_view>
 
 namespace vkShade
 {
@@ -13,8 +18,8 @@ namespace vkShade
 
     struct ReshadeFrameState
     {
-        float frame_time {0.0f};
-        uint32_t frame_count {0};
+        float frameTime {0.0f};
+        uint32_t frameCount {0};
         float timer {0.0f};
     };
 
@@ -30,8 +35,8 @@ namespace vkShade
 
         const ReshadeFrameState& begin_frame(Clock::time_point now = Clock::now())
         {
-            m_currentFrame.frame_time = reshade_frame_time(now - m_lastFrame);
-            m_currentFrame.frame_count = static_cast<uint32_t>(
+            m_currentFrame.frameTime = reshade_frame_time(now - m_lastFrame);
+            m_currentFrame.frameCount = static_cast<uint32_t>(
                 m_frameCount % std::numeric_limits<uint32_t>::max());
             m_currentFrame.timer = reshade_frame_time(now - m_start);
 
@@ -48,4 +53,65 @@ namespace vkShade
         uint64_t m_frameCount {0};
         ReshadeFrameState m_currentFrame;
     };
+
+    struct ReshadePingPongState
+    {
+        float min {0.0f};
+        float max {1.0f};
+        float stepMin {0.0f};
+        float stepMax {0.0f};
+        float smoothing {0.0f};
+        std::array<float, 2> value {0.0f, 0.0f};
+
+        float next_step(int randomValue) const
+        {
+            return stepMax == 0.0f
+                ? stepMin
+                : stepMin + std::fmod(
+                    static_cast<float>(randomValue), stepMax - stepMin + 1.0f);
+        }
+
+        void advance(float deltaTime, float step)
+        {
+            if (value[1] >= 0.0f)
+            {
+                const float smooth = std::max(0.0f, smoothing - (max - value[0]));
+                value[0] += std::max(step - smooth, 0.05f) * deltaTime;
+                if (value[0] >= max)
+                {
+                    value[0] = max;
+                    value[1] = -1.0f;
+                }
+            }
+            else
+            {
+                const float smooth = std::max(0.0f, smoothing - (value[0] - min));
+                value[0] -= std::max(step - smooth, 0.05f) * deltaTime;
+                if (value[0] <= min)
+                {
+                    value[0] = min;
+                    value[1] = 1.0f;
+                }
+            }
+        }
+    };
+
+    struct ReshadeRandomRange
+    {
+        int32_t min {0};
+        int32_t max {RAND_MAX};
+
+        int32_t value(uint32_t randomValue) const
+        {
+            const uint64_t width = static_cast<uint64_t>(
+                std::abs(static_cast<int64_t>(max) - min)) + 1;
+            return static_cast<int32_t>(
+                static_cast<int64_t>(min) + static_cast<int64_t>(randomValue % width));
+        }
+    };
+
+    inline bool reshade_uniform_uses_initializer(std::string_view source)
+    {
+        return source.empty();
+    }
 }

--- a/src/vk/reshade_uniforms.cpp
+++ b/src/vk/reshade_uniforms.cpp
@@ -7,6 +7,7 @@
 #include <spdlog/spdlog.h>
 
 #include "vk/buffer.hpp"
+#include "vk/reshade_runtime.hpp"
 
 static bool uniform_has_source(const reshadefx::uniform& uniform, const std::string& source)
 {
@@ -30,9 +31,9 @@ vkShade::FrameTimeUniform::FrameTimeUniform(reshadefx::uniform uniform)
 void vkShade::FrameTimeUniform::update(VulkanBuffer& buffer)
 {
     auto currentFrame = std::chrono::steady_clock::now();
-    std::chrono::duration<float> duration = currentFrame - m_lastFrame;
+    auto duration = currentFrame - m_lastFrame;
     m_lastFrame = currentFrame;
-    float frametime = duration.count();
+    float frametime = reshade_frame_time(duration);
 
     buffer.write(&frametime, m_size, m_offset);
 }

--- a/src/vk/reshade_uniforms.cpp
+++ b/src/vk/reshade_uniforms.cpp
@@ -3,7 +3,6 @@
 #include <chrono>
 #include <effect_module.hpp>
 #include <glm/vec2.hpp>
-#include <random>
 #include <spdlog/spdlog.h>
 
 #include "vk/buffer.hpp"
@@ -29,7 +28,7 @@ vkShade::FrameTimeUniform::FrameTimeUniform(reshadefx::uniform uniform)
 
 void vkShade::FrameTimeUniform::update(VulkanBuffer& buffer, const ReshadeFrameState& frame)
 {
-    buffer.write(&frame.frame_time, m_size, m_offset);
+    buffer.write(&frame.frameTime, m_size, m_offset);
 }
 
 vkShade::FrameCountUniform::FrameCountUniform(reshadefx::uniform uniform)
@@ -42,7 +41,7 @@ vkShade::FrameCountUniform::FrameCountUniform(reshadefx::uniform uniform)
 
 void vkShade::FrameCountUniform::update(VulkanBuffer& buffer, const ReshadeFrameState& frame)
 {
-    buffer.write(&frame.frame_count, m_size, m_offset);
+    buffer.write(&frame.frameCount, m_size, m_offset);
 }
 
 vkShade::DateUniform::DateUniform(reshadefx::uniform uniform)
@@ -91,61 +90,24 @@ vkShade::PingPongUniform::PingPongUniform(reshadefx::uniform uniform)
 
     for (const auto& a : uniform.annotations)
     {
-        if      (a.name == "min")       m_min       = to_float(a);
-        else if (a.name == "max")       m_max       = to_float(a);
-        else if (a.name == "smoothing") m_smoothing = to_float(a);
+        if      (a.name == "min")       m_state.min       = to_float(a);
+        else if (a.name == "max")       m_state.max       = to_float(a);
+        else if (a.name == "smoothing") m_state.smoothing = to_float(a);
         else if (a.name == "step")
         {
-            m_stepMin = to_float(a, 0);
-            m_stepMax = to_float(a, 1);
+            m_state.stepMin = to_float(a, 0);
+            m_state.stepMax = to_float(a, 1);
         }
     }
 
-    m_lastFrame = std::chrono::steady_clock::now();
-    m_offset    = uniform.offset;
-    m_size      = uniform.size;
+    m_offset = uniform.offset;
+    m_size   = uniform.size;
 }
 
-void vkShade::PingPongUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
+void vkShade::PingPongUniform::update(VulkanBuffer& buffer, const ReshadeFrameState& frame)
 {
-    // Compute delta time and update tracking
-    auto now = std::chrono::steady_clock::now();
-    float deltaTime = std::chrono::duration<float>(now - m_lastFrame).count();
-    m_lastFrame = now;
-
-    // Pick a step size
-    float step = m_stepMin;
-    if (m_stepMax != 0.0f)
-    {
-        static std::mt19937 rng(std::random_device{}());
-        std::uniform_real_distribution<float> dist(m_stepMin, m_stepMax);
-        step = dist(rng);
-    }
-
-    // If going forwards, calculate smoothing reduction based on how
-    //  close we are to m_max, and apply it to step.
-    if (m_currentValue[1] >= 0.0f)
-    {
-        float smooth = std::max(0.0f, m_smoothing - (m_max - m_currentValue[0]));
-        m_currentValue[0] += std::max(step - smooth, 0.05f) * deltaTime;
-        if (m_currentValue[0] >= m_max)
-        {
-            m_currentValue[0] = m_max;
-            m_currentValue[1] = -1.0f;
-        }
-    }
-    else  // If going backwards, same logic in reverse.
-    {
-        float smooth = std::max(0.0f, m_smoothing - (m_currentValue[0] - m_min));
-        m_currentValue[0] -= std::max(step - smooth, 0.05f) * deltaTime;
-        if (m_currentValue[0] <= m_min)
-        {
-            m_currentValue[0] = m_min;
-            m_currentValue[1] = 1.0f;
-        }
-    }
-
-    buffer.write(m_currentValue, m_size, m_offset);
+    m_state.advance(frame.frameTime * 0.001f, m_state.next_step(std::rand()));
+    buffer.write(m_state.value.data(), m_size, m_offset);
 }
 
 vkShade::RandomUniform::RandomUniform(reshadefx::uniform uniform)
@@ -159,8 +121,8 @@ vkShade::RandomUniform::RandomUniform(reshadefx::uniform uniform)
 
     for (const auto& a : uniform.annotations)
     {
-        if      (a.name == "min") m_min = to_int(a);
-        else if (a.name == "max") m_max = to_int(a);
+        if      (a.name == "min") m_range.min = to_int(a);
+        else if (a.name == "max") m_range.max = to_int(a);
     }
 
     m_offset = uniform.offset;
@@ -169,9 +131,7 @@ vkShade::RandomUniform::RandomUniform(reshadefx::uniform uniform)
 
 void vkShade::RandomUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
-    static std::mt19937 rng(std::random_device{}());
-    std::uniform_int_distribution<int32_t> dist(m_min, m_max);
-    int32_t value = dist(rng);
+    const int32_t value = m_range.value(static_cast<uint32_t>(std::rand()));
     buffer.write(&value, m_size, m_offset);
 }
 

--- a/src/vk/reshade_uniforms.cpp
+++ b/src/vk/reshade_uniforms.cpp
@@ -23,19 +23,13 @@ vkShade::FrameTimeUniform::FrameTimeUniform(reshadefx::uniform uniform)
 {
     assert(uniform_has_source(uniform, "frametime"));
 
-    m_lastFrame = std::chrono::steady_clock::now();
-    m_offset    = uniform.offset;
-    m_size      = uniform.size;
+    m_offset = uniform.offset;
+    m_size   = uniform.size;
 }
 
-void vkShade::FrameTimeUniform::update(VulkanBuffer& buffer)
+void vkShade::FrameTimeUniform::update(VulkanBuffer& buffer, const ReshadeFrameState& frame)
 {
-    auto currentFrame = std::chrono::steady_clock::now();
-    auto duration = currentFrame - m_lastFrame;
-    m_lastFrame = currentFrame;
-    float frametime = reshade_frame_time(duration);
-
-    buffer.write(&frametime, m_size, m_offset);
+    buffer.write(&frame.frame_time, m_size, m_offset);
 }
 
 vkShade::FrameCountUniform::FrameCountUniform(reshadefx::uniform uniform)
@@ -46,10 +40,9 @@ vkShade::FrameCountUniform::FrameCountUniform(reshadefx::uniform uniform)
     m_size   = uniform.size;
 }
 
-void vkShade::FrameCountUniform::update(VulkanBuffer& buffer)
+void vkShade::FrameCountUniform::update(VulkanBuffer& buffer, const ReshadeFrameState& frame)
 {
-    buffer.write(&m_count, m_size, m_offset);
-    m_count++;
+    buffer.write(&frame.frame_count, m_size, m_offset);
 }
 
 vkShade::DateUniform::DateUniform(reshadefx::uniform uniform)
@@ -60,7 +53,7 @@ vkShade::DateUniform::DateUniform(reshadefx::uniform uniform)
     m_size   = uniform.size;
 }
 
-void vkShade::DateUniform::update(VulkanBuffer& buffer)
+void vkShade::DateUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     auto        now         = std::chrono::system_clock::now();
     std::time_t nowC        = std::chrono::system_clock::to_time_t(now);
@@ -78,18 +71,13 @@ vkShade::TimerUniform::TimerUniform(reshadefx::uniform uniform)
 {
     assert(uniform_has_source(uniform, "timer"));
 
-    m_startTime = std::chrono::steady_clock::now();
-    m_offset    = uniform.offset;
-    m_size      = uniform.size;
+    m_offset = uniform.offset;
+    m_size   = uniform.size;
 }
 
-void vkShade::TimerUniform::update(VulkanBuffer& buffer)
+void vkShade::TimerUniform::update(VulkanBuffer& buffer, const ReshadeFrameState& frame)
 {
-    auto currentFrame = std::chrono::steady_clock::now();
-    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(currentFrame - m_startTime);
-    float timer = static_cast<float>(elapsed.count());
-
-    buffer.write(&timer, m_size, m_offset);
+    buffer.write(&frame.timer, m_size, m_offset);
 }
 
 vkShade::PingPongUniform::PingPongUniform(reshadefx::uniform uniform)
@@ -118,7 +106,7 @@ vkShade::PingPongUniform::PingPongUniform(reshadefx::uniform uniform)
     m_size      = uniform.size;
 }
 
-void vkShade::PingPongUniform::update(VulkanBuffer& buffer)
+void vkShade::PingPongUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     // Compute delta time and update tracking
     auto now = std::chrono::steady_clock::now();
@@ -179,7 +167,7 @@ vkShade::RandomUniform::RandomUniform(reshadefx::uniform uniform)
     m_size   = uniform.size;
 }
 
-void vkShade::RandomUniform::update(VulkanBuffer& buffer)
+void vkShade::RandomUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     static std::mt19937 rng(std::random_device{}());
     std::uniform_int_distribution<int32_t> dist(m_min, m_max);
@@ -195,7 +183,7 @@ vkShade::KeyUniform::KeyUniform(reshadefx::uniform uniform)
     m_size   = uniform.size;
 }
 
-void vkShade::KeyUniform::update(VulkanBuffer& buffer)
+void vkShade::KeyUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     // TODO: Handle key press uniforms
     VkBool32 keyPressed = VK_FALSE;
@@ -210,7 +198,7 @@ vkShade::MouseButtonUniform::MouseButtonUniform(reshadefx::uniform uniform)
     m_size   = uniform.size;
 }
 
-void vkShade::MouseButtonUniform::update(VulkanBuffer& buffer)
+void vkShade::MouseButtonUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     // TODO: Handle mouse button uniforms
     VkBool32 buttonPressed = VK_FALSE;
@@ -225,7 +213,7 @@ vkShade::MousePointUniform::MousePointUniform(reshadefx::uniform uniform)
     m_size   = uniform.size;
 }
 
-void vkShade::MousePointUniform::update(VulkanBuffer& buffer)
+void vkShade::MousePointUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     // TODO: Handle mouse point uniforms
     glm::vec2 mousePos {0.0f, 0.0f};
@@ -240,7 +228,7 @@ vkShade::MouseDeltaUniform::MouseDeltaUniform(reshadefx::uniform uniform)
     m_size   = uniform.size;
 }
 
-void vkShade::MouseDeltaUniform::update(VulkanBuffer& buffer)
+void vkShade::MouseDeltaUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     // TODO: Handle mouse point uniforms
     glm::vec2 mouseDelta {0.0f, 0.0f};
@@ -255,7 +243,7 @@ vkShade::MouseWheelUniform::MouseWheelUniform(reshadefx::uniform uniform)
     m_size   = uniform.size;
 }
 
-void vkShade::MouseWheelUniform::update(VulkanBuffer& buffer)
+void vkShade::MouseWheelUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     // TODO: Handle mouse wheel uniforms
     glm::vec2 mouseWheel {0.0f, 0.0f};
@@ -270,7 +258,7 @@ vkShade::DepthUniform::DepthUniform(reshadefx::uniform uniform)
     m_size   = uniform.size;
 }
 
-void vkShade::DepthUniform::update(VulkanBuffer& buffer)
+void vkShade::DepthUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     // TODO: Handle depth ready uniforms
     VkBool32 hasDepth = VK_FALSE;
@@ -285,7 +273,7 @@ vkShade::OverlayOpenUniform::OverlayOpenUniform(reshadefx::uniform uniform)
     m_size   = uniform.size;
 }
 
-void vkShade::OverlayOpenUniform::update(VulkanBuffer& buffer)
+void vkShade::OverlayOpenUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     // TODO: Handle overlay open uniforms
     VkBool32 overlayOpen = VK_FALSE;
@@ -300,7 +288,7 @@ vkShade::OverlayActiveUniform::OverlayActiveUniform(reshadefx::uniform uniform)
     m_size   = uniform.size;
 }
 
-void vkShade::OverlayActiveUniform::update(VulkanBuffer& buffer)
+void vkShade::OverlayActiveUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     // TODO: Handle overlay active uniforms
     int32_t overlayActive = 0;
@@ -315,7 +303,7 @@ vkShade::OverlayHoveredUniform::OverlayHoveredUniform(reshadefx::uniform uniform
     m_size   = uniform.size;
 }
 
-void vkShade::OverlayHoveredUniform::update(VulkanBuffer& buffer)
+void vkShade::OverlayHoveredUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     // TODO: Handle overlay hovered uniforms
     int32_t overlayHovered = 0;
@@ -330,7 +318,7 @@ vkShade::ScreenshotUniform::ScreenshotUniform(reshadefx::uniform uniform)
     m_size   = uniform.size;
 }
 
-void vkShade::ScreenshotUniform::update(VulkanBuffer& buffer)
+void vkShade::ScreenshotUniform::update(VulkanBuffer& buffer, const ReshadeFrameState&)
 {
     // TODO: Handle screenshot uniforms? (if in-scope)
     VkBool32 isScreenshot = VK_FALSE;

--- a/src/vk/reshade_uniforms.hpp
+++ b/src/vk/reshade_uniforms.hpp
@@ -10,6 +10,7 @@ namespace reshadefx
 
 namespace vkShade
 {
+    struct ReshadeFrameState;
     class VulkanBuffer;
 
     // Base class for a ReShade built-in uniform. These require special handling.
@@ -17,7 +18,7 @@ namespace vkShade
     {
     public:
         virtual ~ReshadeUniform() = default;
-        virtual void update(VulkanBuffer& buffer) = 0;
+        virtual void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) = 0;
 
     protected:
         ReshadeUniform() = default;
@@ -30,44 +31,35 @@ namespace vkShade
     {
     public:
         FrameTimeUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
-
-    private:
-        std::chrono::steady_clock::time_point m_lastFrame;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
     class FrameCountUniform : public ReshadeUniform
     {
     public:
         FrameCountUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
-
-    private:
-        uint32_t m_count {0};
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
     class DateUniform : public ReshadeUniform
     {
     public:
         DateUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
     class TimerUniform : public ReshadeUniform
     {
     public:
         TimerUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
-
-    private:
-        std::chrono::steady_clock::time_point m_startTime;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
  class PingPongUniform : public ReshadeUniform
     {
     public:
         PingPongUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
 
     private:
         std::chrono::steady_clock::time_point m_lastFrame;
@@ -85,7 +77,7 @@ namespace vkShade
     {
     public:
         RandomUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
 
     private:
         int32_t m_max {0};
@@ -96,69 +88,69 @@ namespace vkShade
     {
     public:
         KeyUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
     class MouseButtonUniform : public ReshadeUniform
     {
     public:
         MouseButtonUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
     class MousePointUniform : public ReshadeUniform
     {
     public:
         MousePointUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
     class MouseDeltaUniform : public ReshadeUniform
     {
     public:
         MouseDeltaUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
     class MouseWheelUniform : public ReshadeUniform
     {
     public:
         MouseWheelUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
     class DepthUniform : public ReshadeUniform
     {
     public:
         DepthUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
     class OverlayOpenUniform : public ReshadeUniform
     {
     public:
         OverlayOpenUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
     class OverlayActiveUniform : public ReshadeUniform
     {
     public:
         OverlayActiveUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
     class OverlayHoveredUniform : public ReshadeUniform
     {
     public:
         OverlayHoveredUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 
     class ScreenshotUniform : public ReshadeUniform
     {
     public:
         ScreenshotUniform(reshadefx::uniform uniform);
-        void update(VulkanBuffer& buffer) override;
+        void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
     };
 } // namespace vkShade

--- a/src/vk/reshade_uniforms.hpp
+++ b/src/vk/reshade_uniforms.hpp
@@ -3,6 +3,8 @@
 #include <chrono>
 #include <cstdint>
 
+#include "vk/reshade_runtime.hpp"
+
 namespace reshadefx
 {
     struct uniform;
@@ -10,7 +12,6 @@ namespace reshadefx
 
 namespace vkShade
 {
-    struct ReshadeFrameState;
     class VulkanBuffer;
 
     // Base class for a ReShade built-in uniform. These require special handling.
@@ -62,14 +63,7 @@ namespace vkShade
         void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
 
     private:
-        std::chrono::steady_clock::time_point m_lastFrame;
-
-        float m_min             {0.0f};
-        float m_max             {0.0f};
-        float m_stepMin         {0.0f};
-        float m_stepMax         {0.0f};
-        float m_smoothing       {0.0f};
-        float m_currentValue[2] {0.0f, 1.0f};
+        ReshadePingPongState m_state;
     };
 
 
@@ -80,8 +74,7 @@ namespace vkShade
         void update(VulkanBuffer& buffer, const ReshadeFrameState& frame) override;
 
     private:
-        int32_t m_max {0};
-        int32_t m_min {0};
+        ReshadeRandomRange m_range;
     };
 
     class KeyUniform : public ReshadeUniform

--- a/src/vk/swapchain.cpp
+++ b/src/vk/swapchain.cpp
@@ -152,6 +152,7 @@ void vkShade::VulkanSwapchain::on_effects_changed(std::vector<std::string> effec
 void vkShade::VulkanSwapchain::render(uint32_t imageIndex)
 {
     VulkanImage* swapchainImage = m_images.at(imageIndex).get();
+    const ReshadeFrameState& reshadeFrame = m_reshadeRuntime.begin_frame();
 
     // Wait until the previous command buffer has finished executing. Timeout of 1 second.
 	VK_CHECK(m_device.dispatch.WaitForFences(m_device.handle, 1, &m_fence, true, 1000000000));
@@ -198,7 +199,7 @@ void vkShade::VulkanSwapchain::render(uint32_t imageIndex)
                 continue;
 
             // Update the effect uniforms
-            effect->update();
+            effect->update(reshadeFrame);
 
             // Barrier: Ensure read image is ready to sample
             readImage->transition_layout(m_commandBuffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);

--- a/src/vk/swapchain.hpp
+++ b/src/vk/swapchain.hpp
@@ -6,6 +6,7 @@
 
 #include "object.hpp"
 #include "reshade_effect.hpp"
+#include "reshade_runtime.hpp"
 
 namespace vkShade
 {
@@ -42,5 +43,6 @@ namespace vkShade
         std::vector<std::shared_ptr<ReshadeEffect>> m_effects;
         std::shared_ptr<VulkanImage> m_pingPongA;
         std::shared_ptr<VulkanImage> m_pingPongB;
+        ReshadeRuntime m_reshadeRuntime;
     };
 }  // namespace vkShade

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -36,7 +36,16 @@ event_bus_tests = executable('event_bus_tests',
   include_directories : include_directories('../src/core')
 )
 
+reshade_runtime_tests = executable('reshade_runtime_tests',
+  'reshade_runtime_tests.cpp',
+  dependencies : [
+    catch2,
+  ],
+  include_directories : include_directories('../src')
+)
+
 test('ConfigObserver', config_observer_tests)
 test('ConfigParser', config_parser_tests)
 test('ConfigStore', config_store_tests)
 test('EventBus', event_bus_tests)
+test('ReShadeRuntime', reshade_runtime_tests)

--- a/tests/reshade_runtime_tests.cpp
+++ b/tests/reshade_runtime_tests.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <cstdlib>
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -19,16 +20,39 @@ TEST_CASE("ReShade runtime values are sampled once per presented frame")
     vkShade::ReshadeRuntime runtime(start);
 
     const auto first = runtime.begin_frame(start + 16ms);
-    REQUIRE(first.frame_time == Catch::Approx(16.0f));
-    REQUIRE(first.frame_count == 0);
+    REQUIRE(first.frameTime == Catch::Approx(16.0f));
+    REQUIRE(first.frameCount == 0);
     REQUIRE(first.timer == Catch::Approx(16.0f));
 
     // Every effect rendered in this presentation observes one shared sample.
-    REQUIRE(runtime.current_frame().frame_count == first.frame_count);
-    REQUIRE(runtime.current_frame().frame_time == first.frame_time);
+    REQUIRE(runtime.current_frame().frameCount == first.frameCount);
+    REQUIRE(runtime.current_frame().frameTime == first.frameTime);
 
     const auto second = runtime.begin_frame(start + 36ms);
-    REQUIRE(second.frame_time == Catch::Approx(20.0f));
-    REQUIRE(second.frame_count == 1);
+    REQUIRE(second.frameTime == Catch::Approx(20.0f));
+    REQUIRE(second.frameCount == 1);
     REQUIRE(second.timer == Catch::Approx(36.0f));
+}
+
+TEST_CASE("ReShade generated uniforms use the reference defaults")
+{
+    vkShade::ReshadePingPongState pingPong;
+    pingPong.advance(1.0f, pingPong.stepMin);
+
+    // With ReShade's implicit max=1, the minimum 0.05/s increment moves
+    // forward instead of immediately bouncing off an implicit max=0.
+    REQUIRE(pingPong.value[0] == Catch::Approx(0.05f));
+    REQUIRE(pingPong.value[1] >= 0.0f);
+
+    pingPong.stepMin = 0.5f;
+    pingPong.stepMax = 1.0f;
+    REQUIRE(pingPong.next_step(2) == Catch::Approx(1.0f));
+
+    const vkShade::ReshadeRandomRange random;
+    REQUIRE(random.min == 0);
+    REQUIRE(random.max == RAND_MAX);
+    REQUIRE(random.value(42) == 42);
+
+    REQUIRE(vkShade::reshade_uniform_uses_initializer(""));
+    REQUIRE_FALSE(vkShade::reshade_uniform_uses_initializer("addon_defined"));
 }

--- a/tests/reshade_runtime_tests.cpp
+++ b/tests/reshade_runtime_tests.cpp
@@ -11,3 +11,24 @@ TEST_CASE("ReShade frame time is expressed in milliseconds")
 {
     REQUIRE(vkShade::reshade_frame_time(16ms) == Catch::Approx(16.0f));
 }
+
+TEST_CASE("ReShade runtime values are sampled once per presented frame")
+{
+    using Clock = std::chrono::steady_clock;
+    const Clock::time_point start {};
+    vkShade::ReshadeRuntime runtime(start);
+
+    const auto first = runtime.begin_frame(start + 16ms);
+    REQUIRE(first.frame_time == Catch::Approx(16.0f));
+    REQUIRE(first.frame_count == 0);
+    REQUIRE(first.timer == Catch::Approx(16.0f));
+
+    // Every effect rendered in this presentation observes one shared sample.
+    REQUIRE(runtime.current_frame().frame_count == first.frame_count);
+    REQUIRE(runtime.current_frame().frame_time == first.frame_time);
+
+    const auto second = runtime.begin_frame(start + 36ms);
+    REQUIRE(second.frame_time == Catch::Approx(20.0f));
+    REQUIRE(second.frame_count == 1);
+    REQUIRE(second.timer == Catch::Approx(36.0f));
+}

--- a/tests/reshade_runtime_tests.cpp
+++ b/tests/reshade_runtime_tests.cpp
@@ -1,0 +1,13 @@
+#include <chrono>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "vk/reshade_runtime.hpp"
+
+using namespace std::chrono_literals;
+
+TEST_CASE("ReShade frame time is expressed in milliseconds")
+{
+    REQUIRE(vkShade::reshade_frame_time(16ms) == Catch::Approx(16.0f));
+}


### PR DESCRIPTION
## Summary

Align ReShade runtime-generated uniforms with the reference implementation.

## Changes

- Report `source = "frametime"` in milliseconds instead of seconds.
  - Sample frame time, frame count, and timer once per presented frame.
  - All effects in the chain now observe the same values.
- Reloading or reordering effects no longer resets their timer or frame count.
- Match ReShade's generated-uniform behavior:
  - `pingpong` defaults to `max = 1`.
  - `pingpong` uses the shared frame duration and ReShade's step calculation.
  - `random` defaults to `max = RAND_MAX`.
  - Non-empty `source` uniforms, including unknown sources, are initialized to zero.
  - An empty `source` annotation is treated as a regular uniform.

The runtime calculations were separated from Vulkan buffer access so their time-dependent behavior can be tested deterministically.

## Motivation

ReShade shaders expect `frametime` in milliseconds. vkShade previously supplied seconds, causing temporal shaders such as eye adaptation to evolve roughly 1000 times too slowly.

Frame timing and counters were also maintained by individual uniform instances. This made values depend on effect order and reset them whenever effects were recreated.

## Testing

Added focused Catch2 regression tests covering:

- millisecond frame-time conversion;
- shared runtime values across a presented frame;
- frame-time, timer, and frame-count progression;
- ReShade defaults for `pingpong` and `random`;
- ping-pong step behavior;
- initializer handling for source uniforms.

All five registered test targets pass, and the complete Vulkan layer builds successfully.