### PR TITLE
fix(logging): initialize and isolate the logger

### DIFF
--- a/src/config/config_manager.cpp
+++ b/src/config/config_manager.cpp
@@ -1,6 +1,6 @@
 #include "config_manager.hpp"
 
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 
 #include "config_globals.hpp"
 
@@ -34,10 +34,10 @@ vkShade::ConfigManager::ConfigManager()
     {
         if (m_config.load(filePath))
         {
-            spdlog::info("Loaded config file: {}", filePath);
+            Logger::info("Loaded config file: {}", filePath);
             return;
         }
     }
 
-    spdlog::warn("No config file found");
+    Logger::warn("No config file found");
 }

--- a/src/config/config_store.cpp
+++ b/src/config/config_store.cpp
@@ -4,7 +4,7 @@
 #include <map>
 
 #include <ini.h>
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 
 // Static callback function for inih parser
 static int config_ini_handler(void* user, const char* section, const char* name, const char* value)
@@ -15,7 +15,7 @@ static int config_ini_handler(void* user, const char* section, const char* name,
     std::string key = std::string(section) + "::" + std::string(name);
     (*config)[key] = value;
 
-    spdlog::trace("Parsed configuration option: {}::{} ({})", section, name, value);
+    vkShade::Logger::trace("Parsed configuration option: {}::{} ({})", section, name, value);
 
     return 1;  // Success
 }
@@ -43,7 +43,7 @@ bool vkShade::ConfigStore::load(std::filesystem::path filePath)
     int result = ini_parse(filePath.string().c_str(), config_ini_handler, &m_config);
     if (result != 0)
     {
-        spdlog::error("Failed to load or parse config file: {}", filePath.c_str());
+        Logger::error("Failed to load or parse config file: {}", filePath.c_str());
         return false;
     }
 
@@ -56,7 +56,7 @@ bool vkShade::ConfigStore::save(std::filesystem::path filePath)
     std::ofstream file(filePath);
     if (!file.is_open())
     {
-        spdlog::error("Failed to open config file for writing: {}", filePath.string());
+        Logger::error("Failed to open config file for writing: {}", filePath.string());
         return false;
     }
 
@@ -108,7 +108,7 @@ bool vkShade::ConfigStore::save(std::filesystem::path filePath)
     }
 
     m_currentFile = filePath;
-    spdlog::trace("Saved configuration to: {}", filePath.string());
+    Logger::trace("Saved configuration to: {}", filePath.string());
     return true;
 }
 

--- a/src/core/logger.hpp
+++ b/src/core/logger.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+namespace vkShade
+{
+    // vkShade deliberately owns this logger instead of using spdlog's global
+    // registry. Other Vulkan layers in the same process may replace or clear
+    // that global registry at any time.
+    class Logger
+    {
+    public:
+        static void trace(std::string_view msg)
+        {
+            get().trace(msg);
+        }
+
+        template <typename... Args>
+        static void trace(spdlog::format_string_t<Args...> fmt, Args&&... args)
+        {
+            get().trace(fmt, std::forward<Args>(args)...);
+        }
+
+        static void debug(std::string_view msg)
+        {
+            get().debug(msg);
+        }
+
+        template <typename... Args>
+        static void debug(spdlog::format_string_t<Args...> fmt, Args&&... args)
+        {
+            get().debug(fmt, std::forward<Args>(args)...);
+        }
+
+        static void info(std::string_view msg)
+        {
+            get().info(msg);
+        }
+
+        template <typename... Args>
+        static void info(spdlog::format_string_t<Args...> fmt, Args&&... args)
+        {
+            get().info(fmt, std::forward<Args>(args)...);
+        }
+
+        static void warn(std::string_view msg)
+        {
+            get().warn(msg);
+        }
+
+        template <typename... Args>
+        static void warn(spdlog::format_string_t<Args...> fmt, Args&&... args)
+        {
+            get().warn(fmt, std::forward<Args>(args)...);
+        }
+
+        static void error(std::string_view msg)
+        {
+            get().error(msg);
+        }
+
+        template <typename... Args>
+        static void error(spdlog::format_string_t<Args...> fmt, Args&&... args)
+        {
+            get().error(fmt, std::forward<Args>(args)...);
+        }
+
+        static void critical(std::string_view msg)
+        {
+            get().critical(msg);
+        }
+
+        template <typename... Args>
+        static void critical(spdlog::format_string_t<Args...> fmt, Args&&... args)
+        {
+            get().critical(fmt, std::forward<Args>(args)...);
+        }
+
+    private:
+        static spdlog::logger& get()
+        {
+            // Keep the logger independent from spdlog's process-wide registry.
+            static auto logger = []
+            {
+                std::vector<spdlog::sink_ptr> sinks;
+                sinks.push_back(std::make_shared<spdlog::sinks::stderr_color_sink_mt>());
+
+                if (const char* path = std::getenv("VKSHADE_LOG_FILE"))
+                    // Function-local static initialization opens and truncates the log
+                    // exactly once, even when accessed concurrently from multiple threads.
+                    sinks.push_back(
+                        std::make_shared<spdlog::sinks::basic_file_sink_mt>(path, true));
+
+                auto result = std::make_shared<spdlog::logger>(
+                    "vkShade", sinks.begin(), sinks.end());
+                result->flush_on(spdlog::level::trace);
+
+                const char* configuredLevel = std::getenv("VKSHADE_LOG_LEVEL");
+                const std::string level = configuredLevel ? configuredLevel : "info";
+                if (level == "trace")
+                    result->set_level(spdlog::level::trace);
+                else if (level == "debug")
+                    result->set_level(spdlog::level::debug);
+                else if (level == "info")
+                    result->set_level(spdlog::level::info);
+                else if (level == "warn" || level == "warning")
+                    result->set_level(spdlog::level::warn);
+                else if (level == "error")
+                    result->set_level(spdlog::level::err);
+                else if (level == "critical")
+                    result->set_level(spdlog::level::critical);
+                else if (level == "off")
+                    result->set_level(spdlog::level::off);
+                else
+                    result->set_level(spdlog::level::info);
+
+                result->debug("vkShade logger initialized");
+                return result;
+            }();
+
+            return *logger;
+        }
+    };
+}

--- a/src/core/resource_cache.hpp
+++ b/src/core/resource_cache.hpp
@@ -5,7 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 
 #include "resource.hpp"
 #include "resource_factory.hpp"
@@ -29,7 +29,7 @@ namespace vkShade
             if (auto resource = try_get(cacheKey))
                 return resource;
 
-            spdlog::debug("Loading resource: {}", cacheKey);
+            Logger::debug("Loading resource: {}", cacheKey);
             std::shared_ptr<T> resource;
 
             {
@@ -41,14 +41,14 @@ namespace vkShade
 
             if (!resource || !resource->is_valid())
             {
-                spdlog::error("Failed to create resource: {}", cacheKey);
+                Logger::error("Failed to create resource: {}", cacheKey);
                 return nullptr;
             }
 
             // Actually load the resource (outside of lock due to expense)
             if (!resource->load())
             {
-                spdlog::error("Failed to load resource: {}", cacheKey);
+                Logger::error("Failed to load resource: {}", cacheKey);
                 std::unique_lock lock(m_mutex);  // Write lock
                 m_cache.erase(cacheKey);
                 return nullptr;

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -5,6 +5,7 @@
 #include <vulkan/vulkan_core.h>
 
 #include "core/service_locator.hpp"
+#include "core/logger.hpp"
 #include "hooks/hooks.hpp"
 #include "input/input_manager.hpp"
 #include "windows/main_window.hpp"
@@ -70,7 +71,7 @@ vkShade::GuiManager::GuiManager(VulkanDevice deviceContext, VkFormat swapchainFo
         PFN_vkVoidFunction func = vkShade_GetDeviceProcAddr(ctx->handle, function_name);
         if (func)
         {
-            spdlog::trace("[ImGui] Loaded {} from device table:  {}", function_name, (void*)func);
+            Logger::trace("[ImGui] Loaded {} from device table:  {}", function_name, (void*)func);
             return func;
         }
 
@@ -78,11 +79,11 @@ vkShade::GuiManager::GuiManager(VulkanDevice deviceContext, VkFormat swapchainFo
         func = vkShade_GetInstanceProcAddr(instance.handle, function_name);
         if (func)
         {
-            spdlog::trace("[ImGui] Loaded {} from instance table: {}", function_name, (void*)func);
+            Logger::trace("[ImGui] Loaded {} from instance table: {}", function_name, (void*)func);
             return func;
         }
 
-        spdlog::error("[ImGui] Failed to load function: {}", function_name);
+        Logger::error("[ImGui] Failed to load function: {}", function_name);
         return nullptr;
     }, &deviceContext);
 

--- a/src/hooks/hooks_device.cpp
+++ b/src/hooks/hooks_device.cpp
@@ -1,7 +1,6 @@
 #include "hooks.hpp"
 
 #include <magic_enum/magic_enum.hpp>
-#include <spdlog/spdlog.h>
 #define VMA_STATIC_VULKAN_FUNCTIONS 0
 #define VMA_DYNAMIC_VULKAN_FUNCTIONS 0
 #define VMA_IMPLEMENTATION
@@ -11,6 +10,7 @@
 
 #include "config/config_manager.hpp"
 #include "core/event_bus.hpp"
+#include "core/logger.hpp"
 #include "core/service_locator.hpp"
 #include "core/resource_cache.hpp"
 #include "gui/gui_manager.hpp"
@@ -23,7 +23,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
     const VkAllocationCallbacks*                pAllocator,
     VkDevice*                                   pDevice)
 {
-    spdlog::trace("Intercepted VkCreateDevice");
+    vkShade::Logger::trace("Intercepted VkCreateDevice");
 
     // Step through the pNext chain until we get to the layer link info
     VkLayerDeviceCreateInfo* layerInfo = (VkLayerDeviceCreateInfo*)pCreateInfo->pNext;
@@ -34,7 +34,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
 
     if(!layerInfo)
     {
-        spdlog::error("Failed to find device layer link info");
+        vkShade::Logger::error("Failed to find device layer link info");
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
@@ -47,7 +47,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
     PFN_vkCreateDevice create_func = (PFN_vkCreateDevice)gipa(VK_NULL_HANDLE, "vkCreateDevice");
     if (!create_func)
     {
-        spdlog::error("Failed to get vkCreateDevice");
+        vkShade::Logger::error("Failed to get vkCreateDevice");
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
@@ -72,7 +72,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
 
     if (!features13 || !features13->dynamicRendering)
     {
-        spdlog::debug("Injecting Dynamic Rendering feature");
+        vkShade::Logger::debug("Injecting Dynamic Rendering feature");
 
         if (features13)
         {
@@ -96,7 +96,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
     VkResult result = create_func(physicalDevice, finalCreateInfo, pAllocator, pDevice);
     if (result != VK_SUCCESS)
     {
-        spdlog::error("Failed to create device: {}", magic_enum::enum_name(result));
+        vkShade::Logger::error("Failed to create device: {}", magic_enum::enum_name(result));
         return result;
     }
 
@@ -125,10 +125,10 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
 		// Find the first queue family which supports graphics and has at least one queue
 		if (queueProperties[queueInfo.queueFamilyIndex].queueFlags & VK_QUEUE_GRAPHICS_BIT)
 		{
-            spdlog::debug("Found graphics capable queue");
+            vkShade::Logger::debug("Found graphics capable queue");
 
             if (pCreateInfo->pQueueCreateInfos[i].pQueuePriorities[0] < 1.0f)
-				spdlog::warn("Selected graphics queue has a low priority: {}", pCreateInfo->pQueueCreateInfos[i].pQueuePriorities[0]);
+				vkShade::Logger::warn("Selected graphics queue has a low priority: {}", pCreateInfo->pQueueCreateInfos[i].pQueuePriorities[0]);
 
 			thisDevice.queueFamilyIndex = queueInfo.queueFamilyIndex;
             thisDevice.dispatch.GetDeviceQueue(thisDevice.handle, thisDevice.queueFamilyIndex, 0, &thisDevice.queue);
@@ -192,7 +192,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
         VkResult vmaResult = vmaCreateAllocator(&allocatorInfo, &thisDevice.allocator);
         if (vmaResult != VK_SUCCESS)
         {
-            spdlog::error("Failed to create memory allocator: {}", magic_enum::enum_name(result));
+            vkShade::Logger::error("Failed to create memory allocator: {}", magic_enum::enum_name(result));
             return VK_ERROR_INITIALIZATION_FAILED;
         }
     }
@@ -208,13 +208,13 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
     vkShade::Locator<vkShade::EventBus>::emplace();
     vkShade::Locator<vkShade::ResourceCache<vkShade::ShaderModule>>::emplace();
 
-    spdlog::info("Layer initialization complete");
+    vkShade::Logger::info("Layer initialization complete");
     return VK_SUCCESS;
 }
 
 VK_LAYER_EXPORT void VKAPI_CALL vkShade_DestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator)
 {
-    spdlog::trace("Intercepted VkDestroyDevice");
+    vkShade::Logger::trace("Intercepted VkDestroyDevice");
 
     // Lock here to prevent race conditions.
     std::unique_lock lock(g_globalLock);

--- a/src/hooks/hooks_instance.cpp
+++ b/src/hooks/hooks_instance.cpp
@@ -1,64 +1,16 @@
 #include "hooks.hpp"
 
-#include <cstdlib>
-#include <mutex>
-
 #include <magic_enum/magic_enum.hpp>
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
 #include <vulkan/vk_layer.h>
+
+#include "core/logger.hpp"
 
 VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkInstance*                                 pInstance)
 {
-    // Initialize spdlog once even when instances are created concurrently.
-    static std::once_flag spdlogInit;
-    std::call_once(spdlogInit, []
-    {
-        std::vector<spdlog::sink_ptr> sinks;
-
-        // Always add console sink
-        auto consoleSink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
-        sinks.push_back(consoleSink);
-
-        // Optionally add file sink
-        const char* logFileEnv = std::getenv("VKSHADE_LOG_FILE");
-        if (logFileEnv != nullptr)
-        {
-            auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFileEnv, true);
-            sinks.push_back(fileSink);
-        }
-
-        auto logger = std::make_shared<spdlog::logger>("vkShade", sinks.begin(), sinks.end());
-        spdlog::set_default_logger(logger);
-        logger->flush_on(spdlog::level::trace);  // Always flush on log events
-
-        // Set log level
-        const char* logLevelEnv = std::getenv("VKSHADE_LOG_LEVEL");
-        std::string level = logLevelEnv ? logLevelEnv : "";
-
-        if (level == "trace")
-            spdlog::set_level(spdlog::level::trace);
-        else if (level == "debug")
-            spdlog::set_level(spdlog::level::debug);
-        else if (level == "info")
-            spdlog::set_level(spdlog::level::info);
-        else if (level == "warn" || level == "warning")
-            spdlog::set_level(spdlog::level::warn);
-        else if (level == "error")
-            spdlog::set_level(spdlog::level::err);
-        else if (level == "critical")
-            spdlog::set_level(spdlog::level::critical);
-        else if (level == "off")
-            spdlog::set_level(spdlog::level::off);
-        else
-            spdlog::set_level(spdlog::level::info);
-    });
-
-    spdlog::trace("Intercepted VkCreateInstance");
+    vkShade::Logger::trace("Intercepted VkCreateInstance");
 
     // Step through the pNext chain until we get to the layer link info
     const VkLayerInstanceCreateInfo* layerInfo = reinterpret_cast<const VkLayerInstanceCreateInfo*>(pCreateInfo->pNext);
@@ -69,7 +21,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateInstance(
 
     if(!layerInfo)
     {
-        spdlog::error("Failed to find instance layer link info");
+        vkShade::Logger::error("Failed to find instance layer link info");
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
@@ -83,7 +35,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateInstance(
     PFN_vkCreateInstance create_func = (PFN_vkCreateInstance)gpa(VK_NULL_HANDLE, "vkCreateInstance");
     if (!create_func)
     {
-        spdlog::error("Failed to get vkCreateInstance");
+        vkShade::Logger::error("Failed to get vkCreateInstance");
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
@@ -95,7 +47,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateInstance(
 	// vkShade requires at least Vulkan 1.3
 	if (appInfo.apiVersion < VK_API_VERSION_1_3)
 	{
-        spdlog::info("Replacing requested Vulkan API version with 1.3");
+        vkShade::Logger::info("Replacing requested Vulkan API version with 1.3");
 		appInfo.apiVersion = VK_API_VERSION_1_3;
 	}
 
@@ -107,7 +59,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateInstance(
     VkResult result = create_func(&modifiedCreateInfo, pAllocator, pInstance);
     if (result != VK_SUCCESS)
     {
-        spdlog::error("Failed to create instance: {}", magic_enum::enum_name(result));
+        vkShade::Logger::error("Failed to create instance: {}", magic_enum::enum_name(result));
         return result;
     }
 
@@ -127,7 +79,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateInstance(
 
 VK_LAYER_EXPORT void VKAPI_CALL vkShade_DestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator)
 {
-    spdlog::trace("Intercepted VkDestroyInstance");
+    vkShade::Logger::trace("Intercepted VkDestroyInstance");
 
     // Lock here to prevent race conditions.
     std::unique_lock lock(g_globalLock);

--- a/src/hooks/hooks_instance.cpp
+++ b/src/hooks/hooks_instance.cpp
@@ -1,6 +1,7 @@
 #include "hooks.hpp"
 
 #include <cstdlib>
+#include <mutex>
 
 #include <magic_enum/magic_enum.hpp>
 #include <spdlog/sinks/basic_file_sink.h>
@@ -13,9 +14,9 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateInstance(
     const VkAllocationCallbacks*                pAllocator,
     VkInstance*                                 pInstance)
 {
-    // Initialize spdlog on first instance creation
-    static bool spdlogInitialized = false;
-    if (!spdlogInitialized)
+    // Initialize spdlog once even when instances are created concurrently.
+    static std::once_flag spdlogInit;
+    std::call_once(spdlogInit, []
     {
         std::vector<spdlog::sink_ptr> sinks;
 
@@ -55,9 +56,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateInstance(
             spdlog::set_level(spdlog::level::off);
         else
             spdlog::set_level(spdlog::level::info);
-
-        spdlogInitialized = true;
-    }
+    });
 
     spdlog::trace("Intercepted VkCreateInstance");
 

--- a/src/hooks/hooks_surface.cpp
+++ b/src/hooks/hooks_surface.cpp
@@ -1,7 +1,7 @@
 #include "hooks.hpp"
 #include "hooks_surface.hpp"
 
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 
 #include "core/service_locator.hpp"
 #include "input/input_backend_wayland.hpp"
@@ -14,7 +14,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateWaylandSurfaceKHR(VkInstance  
                                                                     const VkAllocationCallbacks*         pAllocator,
                                                                     VkSurfaceKHR*                        pSurface)
 {
-    spdlog::trace("Intercepted VkCreateWaylandSurfaceKHR");
+    vkShade::Logger::trace("Intercepted VkCreateWaylandSurfaceKHR");
 
     auto& thisInstance = get_instance_from_handle(instance);
 
@@ -32,7 +32,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateWaylandSurfaceKHR(VkInstance  
         if (!vkShade::Locator<vkShade::InputManager>::has())
             vkShade::Locator<vkShade::InputManager>::emplace<vkShade::InputBackendWayland>(
                 pCreateInfo->display);
-        spdlog::debug("Wayland surface created");
+        vkShade::Logger::debug("Wayland surface created");
     }
 
     return result;
@@ -44,7 +44,7 @@ VK_LAYER_EXPORT VkResult vkShade_CreateXcbSurfaceKHR(VkInstance                 
                                                      const VkAllocationCallbacks*     pAllocator,
                                                      VkSurfaceKHR*                    pSurface)
 {
-    spdlog::trace("Intercepted VkCreateXcbSurfaceKHR");
+    vkShade::Logger::trace("Intercepted VkCreateXcbSurfaceKHR");
 
     auto* xcbCreateInfo = reinterpret_cast<const VkXcbSurfaceCreateInfoKHR*>(pCreateInfo);
     xcb_connection_t* connection = xcbCreateInfo->connection;
@@ -61,8 +61,8 @@ VK_LAYER_EXPORT VkResult vkShade_CreateXcbSurfaceKHR(VkInstance                 
     {
         vkShade::Locator<vkShade::InputManager>::reset();
         vkShade::Locator<vkShade::InputManager>::emplace<vkShade::InputBackendXcb>(connection, window);
-        spdlog::debug("X11 (XCB) surface created");
-        spdlog::warn("XCB input is currently unsupported");
+        vkShade::Logger::debug("X11 (XCB) surface created");
+        vkShade::Logger::warn("XCB input is currently unsupported");
     }
 
     return result;
@@ -73,7 +73,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateXlibSurfaceKHR(VkInstance     
                                                                  const VkAllocationCallbacks*      pAllocator,
                                                                  VkSurfaceKHR*                     pSurface)
 {
-    spdlog::trace("Intercepted VkCreateXlibSurfaceKHR");
+    vkShade::Logger::trace("Intercepted VkCreateXlibSurfaceKHR");
 
     auto* xlibCreateInfo = reinterpret_cast<const VkXlibSurfaceCreateInfoKHR*>(pCreateInfo);
     Window window = xlibCreateInfo->window;
@@ -90,7 +90,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateXlibSurfaceKHR(VkInstance     
     {
         vkShade::Locator<vkShade::InputManager>::reset();
         vkShade::Locator<vkShade::InputManager>::emplace<vkShade::InputBackendXlib>(display, window);
-        spdlog::debug("X11 (Xlib) surface created");
+        vkShade::Logger::debug("X11 (Xlib) surface created");
     }
 
     return result;

--- a/src/hooks/hooks_swapchain.cpp
+++ b/src/hooks/hooks_swapchain.cpp
@@ -5,8 +5,7 @@
 #include <imgui.h>
 #include <imgui_impl_vulkan.h>
 #include <vulkan/vulkan_core.h>
-#include <spdlog/spdlog.h>
-
+#include "core/logger.hpp"
 #include "core/service_locator.hpp"
 #include "input/input_manager.hpp"
 
@@ -18,7 +17,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateSwapchainKHR(VkDevice         
                                                                const VkAllocationCallbacks*    pAllocator,
                                                                VkSwapchainKHR*                 pSwapchain)
 {
-    spdlog::trace("Intercepted VkCreateSwapchainKHR");
+    vkShade::Logger::trace("Intercepted VkCreateSwapchainKHR");
 
     auto& thisDevice = g_vulkanDevices[dispatch_key_from_handle(device)];
 
@@ -37,7 +36,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateSwapchainKHR(VkDevice         
         g_swapchains[*pSwapchain] = std::make_unique<vkShade::VulkanSwapchain>(thisDevice, *pSwapchain, *pCreateInfo);
     }
 
-    spdlog::debug("Swapchain created");
+    vkShade::Logger::debug("Swapchain created");
     return VK_SUCCESS;
 }
 
@@ -45,7 +44,7 @@ VK_LAYER_EXPORT void VKAPI_CALL vkShade_DestroySwapchainKHR(VkDevice            
                                                             VkSwapchainKHR               swapchain,
                                                             const VkAllocationCallbacks* pAllocator)
 {
-    spdlog::trace("Intercepted VkDestroySwapchainKHR");
+    vkShade::Logger::trace("Intercepted VkDestroySwapchainKHR");
 
     // Clean up our bookkeeping data
     {
@@ -57,7 +56,7 @@ VK_LAYER_EXPORT void VKAPI_CALL vkShade_DestroySwapchainKHR(VkDevice            
     auto& thisDevice = g_vulkanDevices[dispatch_key_from_handle(device)];
     thisDevice.dispatch.DestroySwapchainKHR(device, swapchain, pAllocator);
 
-    spdlog::debug("Swapchain destroyed");
+    vkShade::Logger::debug("Swapchain destroyed");
 }
 
 VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_QueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo)
@@ -69,7 +68,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_QueuePresentKHR(VkQueue queue, const
     auto it = g_swapchains.find(pPresentInfo->pSwapchains[0]);
     if (it == g_swapchains.end())
     {
-        spdlog::error("Swapchain not found in present");
+        vkShade::Logger::error("Swapchain not found in present");
         return thisDevice.dispatch.QueuePresentKHR(queue, pPresentInfo);
     }
 
@@ -105,7 +104,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_QueuePresentKHR(VkQueue queue, const
         auto it = g_swapchains.find(swapchain);
         if (it == g_swapchains.end())
         {
-            spdlog::error("Swapchain not found in present");
+            vkShade::Logger::error("Swapchain not found in present");
             return thisDevice.dispatch.QueuePresentKHR(queue, pPresentInfo);
         }
 

--- a/src/input/input_backend_wayland.cpp
+++ b/src/input/input_backend_wayland.cpp
@@ -4,7 +4,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 #include <xkbcommon/xkbcommon.h>
 
 #include "mouse_button_codes.hpp"
@@ -63,12 +63,12 @@ void vkShade::InputBackendWayland::on_pointer_enter(wl_surface* surface, wl_fixe
     float fx = wl_fixed_to_double(x);
     float fy = wl_fixed_to_double(y);
     handle_mouse_motion_event(fx, fy);
-    spdlog::trace("Pointer entered at ({}, {})", fx, fy);
+    Logger::trace("Pointer entered at ({}, {})", fx, fy);
 }
 
 void vkShade::InputBackendWayland::on_pointer_leave(wl_surface* surface)
 {
-    spdlog::trace("Pointer left surface");
+    Logger::trace("Pointer left surface");
 }
 
 void vkShade::InputBackendWayland::on_pointer_motion(uint32_t time, wl_fixed_t x, wl_fixed_t y)
@@ -98,7 +98,7 @@ void vkShade::InputBackendWayland::on_pointer_axis(uint32_t time, uint32_t axis,
 {
     // Handle scroll wheel
     float scroll = wl_fixed_to_double(value);
-    spdlog::trace("Scroll axis {} value {}", axis, scroll);
+    Logger::trace("Scroll axis {} value {}", axis, scroll);
 }
 
 void vkShade::InputBackendWayland::on_registry_global(wl_registry* reg, uint32_t name, const char* interface, uint32_t version)
@@ -107,7 +107,7 @@ void vkShade::InputBackendWayland::on_registry_global(wl_registry* reg, uint32_t
     {
         wl_seat* seat = static_cast<wl_seat*>(wl_registry_bind(reg, name, &wl_seat_interface, 1));
         wl_seat_add_listener(seat, &seat_listener, this);   // Pass 'this' as data* in callbacks
-        spdlog::trace("Bound to wl_seat");
+        Logger::trace("Bound to wl_seat");
     }
 }
 
@@ -118,7 +118,7 @@ void vkShade::InputBackendWayland::on_seat_capabilities(wl_seat* seat, uint32_t 
     {
         m_keyboard = wl_seat_get_keyboard(seat);
         wl_keyboard_add_listener(m_keyboard, &kb_listener, this);  // Pass 'this' as data* in callbacks
-        spdlog::trace("Bound to wl_keyboard");
+        Logger::trace("Bound to wl_keyboard");
     }
 
     // Add pointer handling
@@ -126,7 +126,7 @@ void vkShade::InputBackendWayland::on_seat_capabilities(wl_seat* seat, uint32_t 
     {
         m_pointer = wl_seat_get_pointer(seat);
         wl_pointer_add_listener(m_pointer, &pointer_listener, this);
-        spdlog::trace("Bound to wl_pointer");
+        Logger::trace("Bound to wl_pointer");
     }
 }
 

--- a/src/input/input_backend_xcb.cpp
+++ b/src/input/input_backend_xcb.cpp
@@ -1,6 +1,6 @@
 #include "input_backend_xcb.hpp"
 
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 #include <xcb/xcb.h>
 #include <xcb/xproto.h>
 #include <xkbcommon/xkbcommon.h>
@@ -11,7 +11,7 @@ vkShade::InputBackendXcb::InputBackendXcb(xcb_connection_t* connection, xcb_wind
 {
     if (!m_connection)
     {
-        spdlog::error("[InputBackendXcb] Invalid connection");
+        Logger::error("[InputBackendXcb] Invalid connection");
         return;
     }
 
@@ -127,7 +127,7 @@ void vkShade::InputBackendXcb::on_mouse_button(uint8_t button, bool pressed)
 
     handle_mouse_button_event(mouseButton, pressed);
 
-    spdlog::debug("[InputBackendXcb] Mouse button {} {}",
+    Logger::debug("[InputBackendXcb] Mouse button {} {}",
                   (int)mouseButton, pressed ? "pressed" : "released");
 }
 

--- a/src/input/input_backend_xlib.cpp
+++ b/src/input/input_backend_xlib.cpp
@@ -2,7 +2,7 @@
 
 #include <cstring>
 
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/keysym.h>
@@ -14,7 +14,7 @@ vkShade::InputBackendXlib::InputBackendXlib(Display* display, Window window)
 {
     if (!m_display)
     {
-        spdlog::error("[Xlib] Invalid display");
+        Logger::error("[Xlib] Invalid display");
         return;
     }
 

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -2,7 +2,7 @@
 #include "input/key_codes.hpp"
 
 #include <magic_enum/magic_enum.hpp>
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 #include <xkbcommon/xkbcommon.h>
 
 #include "config/config_manager.hpp"
@@ -10,13 +10,13 @@
 
 vkShade::InputManager::InputManager()
 {
-    spdlog::debug("Initializing InputManager");
+    Logger::debug("Initializing InputManager");
 
     // Initialize XKB context
     m_xkbContext = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     if (!m_xkbContext)
     {
-        spdlog::error("[InputManager] Failed to create XKB context");
+        Logger::error("[InputManager] Failed to create XKB context");
         return;
     }
 
@@ -35,7 +35,7 @@ vkShade::InputManager::InputManager()
 
     if (!m_xkbKeymap)
     {
-        spdlog::error("[InputManager] Failed to create XKB keymap");
+        Logger::error("[InputManager] Failed to create XKB keymap");
         return;
     }
 
@@ -43,7 +43,7 @@ vkShade::InputManager::InputManager()
     m_xkbState = xkb_state_new(m_xkbKeymap);
     if (!m_xkbState)
     {
-        spdlog::error("[InputManager] Failed to create XKB state");
+        Logger::error("[InputManager] Failed to create XKB state");
         return;
     }
 
@@ -90,7 +90,7 @@ vkShade::InputManager::~InputManager()
 void vkShade::InputManager::bind_action(const std::string& actionName, vkShade::KeyCode keyCode)
 {
     m_actionBindings[actionName] = ActionBinding {keyCode};
-    spdlog::debug("Bound action '{}' to '{}'", actionName, magic_enum::enum_name(keyCode));
+    Logger::debug("Bound action '{}' to '{}'", actionName, magic_enum::enum_name(keyCode));
 }
 
 void vkShade::InputManager::handle_keyboard_event(const xkb_keysym_t& keysym, bool pressed)

--- a/src/input/wayland_callbacks.cpp
+++ b/src/input/wayland_callbacks.cpp
@@ -2,8 +2,6 @@
 
 #include <string.h>
 
-#include <spdlog/spdlog.h>
-
 #include "input/input_backend_wayland.hpp"
 
 // Keyboard callbacks

--- a/src/vk/buffer.cpp
+++ b/src/vk/buffer.cpp
@@ -1,7 +1,7 @@
 #include "buffer.hpp"
 
 #include <magic_enum/magic_enum.hpp>
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 #include <vulkan/vulkan_core.h>
 
 #include "macros.hpp"
@@ -12,7 +12,7 @@ vkShade::VulkanBuffer::VulkanBuffer(VulkanDevice& device, size_t size, VkBufferU
     if (size == 0)
         throw std::runtime_error("Cannot initialize buffer with size '0'!");
 
-    spdlog::trace("Creating buffer ({} bytes, {})", size, magic_enum::enum_name(memoryUsage));
+    Logger::trace("Creating buffer ({} bytes, {})", size, magic_enum::enum_name(memoryUsage));
 
     // Allocate the buffer
 	VkBufferCreateInfo bufferInfo = {};
@@ -34,7 +34,7 @@ vkShade::VulkanBuffer::VulkanBuffer(VulkanDevice& device, size_t size, VkBufferU
 
 vkShade::VulkanBuffer::~VulkanBuffer()
 {
-    spdlog::trace("Destroying buffer");
+    Logger::trace("Destroying buffer");
     vmaDestroyBuffer(m_device.allocator, m_buffer, m_allocation);
 }
 
@@ -42,7 +42,7 @@ bool vkShade::VulkanBuffer::copy(VkCommandBuffer cmd, VkBuffer source, size_t si
 {
     if (dstOffset + size > m_allocationInfo.size)
     {
-        spdlog::error("Buffer copy would overflow destination");
+        Logger::error("Buffer copy would overflow destination");
         return false;
     }
 
@@ -60,13 +60,13 @@ bool vkShade::VulkanBuffer::write(const void* data, size_t size, size_t offset)
     // Make sure the buffer is mapped on the CPU
     if (!m_allocationInfo.pMappedData)
     {
-        spdlog::error("Cannot write to unmapped buffer");
+        Logger::error("Cannot write to unmapped buffer");
         return false;
     }
 
     if (offset + size > m_allocationInfo.size)
     {
-        spdlog::error("Write would overflow buffer");
+        Logger::error("Write would overflow buffer");
         return false;
     }
 

--- a/src/vk/image.cpp
+++ b/src/vk/image.cpp
@@ -8,6 +8,7 @@
 #include <vulkan/vulkan_core.h>
 
 #include "core/service_locator.hpp"
+#include "core/logger.hpp"
 #include "config/config_manager.hpp"
 #include "buffer.hpp"
 #include "initializers.hpp"
@@ -16,7 +17,7 @@
 vkShade::VulkanImage::VulkanImage(VulkanDevice& device, const reshadefx::texture& info)
     : VulkanObject(device)
 {
-    spdlog::trace("Creating image from ReShade FX info");
+    Logger::trace("Creating image from ReShade FX info");
 
     m_extent.width  = info.width;
     m_extent.height = info.height;
@@ -113,7 +114,7 @@ vkShade::VulkanImage::VulkanImage(VulkanDevice& device, const reshadefx::texture
 
 void vkShade::VulkanImage::load_from_file(const std::string& filePath)
 {
-    spdlog::trace("Creating image from file: {}", filePath);
+    Logger::trace("Creating image from file: {}", filePath);
 
     int32_t channels;
     stbir_pixel_layout stbirLayout;
@@ -141,7 +142,7 @@ void vkShade::VulkanImage::load_from_file(const std::string& filePath)
 
     if (!pixels)
     {
-        spdlog::error("Failed to load image: {}", filePath);
+        Logger::error("Failed to load image: {}", filePath);
         throw std::runtime_error("Failed to load image: " + filePath);
     }
 
@@ -167,7 +168,7 @@ void vkShade::VulkanImage::load_from_file(const std::string& filePath)
 vkShade::VulkanImage::VulkanImage(VulkanDevice& device, VkExtent2D size, VkFormat format, VkImageUsageFlags usageFlags)
     : VulkanObject(device)
 {
-    spdlog::trace("Creating image (Size: {}x{}, Format: {})",
+    Logger::trace("Creating image (Size: {}x{}, Format: {})",
         size.width, size.height, magic_enum::enum_name(format));
 
     // Set internal properties
@@ -184,7 +185,7 @@ vkShade::VulkanImage::VulkanImage(VulkanDevice& device, VkExtent2D size, VkForma
 vkShade::VulkanImage::VulkanImage(VulkanDevice& device, VkImage image, VkExtent2D size, VkFormat format)
     : VulkanObject(device)
 {
-    spdlog::trace("Wrapping existing image (Size: {}x{}, Format: {})",
+    Logger::trace("Wrapping existing image (Size: {}x{}, Format: {})",
         size.width, size.height, magic_enum::enum_name(format));
 
     // Set internal properties
@@ -201,7 +202,7 @@ vkShade::VulkanImage::VulkanImage(VulkanDevice& device, VkImage image, VkExtent2
 
 vkShade::VulkanImage::~VulkanImage()
 {
-    spdlog::trace("Destroying VulkanImage");
+    Logger::trace("Destroying VulkanImage");
 
     if (m_imageView != VK_NULL_HANDLE)
         m_device.dispatch.DestroyImageView(m_device.handle, m_imageView, nullptr);

--- a/src/vk/macros.hpp
+++ b/src/vk/macros.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
 #include <magic_enum/magic_enum.hpp>
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 #include <vulkan/vulkan.h>
 
 // Abort immediately when there is an error.
-#define VK_CHECK(x)                                                             \
-{                                                                               \
-    VkResult res = x;                                                           \
-    if (res)                                                                    \
-    {                                                                           \
-        spdlog::critical("VkResult code: {}", magic_enum::enum_name(res));      \
-        std::abort();                                                           \
-    }                                                                           \
+#define VK_CHECK(x)                                                                  \
+{                                                                                    \
+    VkResult res = x;                                                                \
+    if (res)                                                                         \
+    {                                                                                \
+        vkShade::Logger::critical("VkResult code: {}", magic_enum::enum_name(res));  \
+        std::abort();                                                                \
+    }                                                                                \
 }

--- a/src/vk/reshade_effect.cpp
+++ b/src/vk/reshade_effect.cpp
@@ -11,7 +11,7 @@
 #include <effect_module.hpp>
 #include <effect_preprocessor.hpp>
 #include <magic_enum/magic_enum.hpp>
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 #include <vulkan/vulkan_core.h>
 
 #include "core/service_locator.hpp"
@@ -25,7 +25,7 @@
 vkShade::ReshadeEffect::ReshadeEffect(VulkanDevice& device, VkExtent2D extent, VkFormat format, std::filesystem::path effectPath)
     : VulkanObject(device), m_extent(extent), m_format(format)
 {
-    spdlog::trace("Creating effect: {}", effectPath.filename().string());
+    Logger::trace("Creating effect: {}", effectPath.filename().string());
 
     // Compile the ReShade effect from source
     reshadefx::effect_module module;
@@ -38,7 +38,7 @@ vkShade::ReshadeEffect::ReshadeEffect(VulkanDevice& device, VkExtent2D extent, V
     this->reflect_pipeline();
     this->reflect_uniforms();
 
-    spdlog::debug("Created effect: {}", effectPath.filename().string());
+    Logger::debug("Created effect: {}", effectPath.filename().string());
 }
 
 vkShade::ReshadeEffect::~ReshadeEffect()
@@ -266,7 +266,7 @@ bool vkShade::ReshadeEffect::compile(VkExtent2D extent, std::filesystem::path fi
 
     if (!pp.append_file(filePath))
 	{
-        spdlog::error(pp.errors());
+        Logger::error(pp.errors());
         return false;
 	}
 
@@ -276,14 +276,14 @@ bool vkShade::ReshadeEffect::compile(VkExtent2D extent, std::filesystem::path fi
 	reshadefx::parser parser;
 	if (!parser.parse(pp.output(), backend.get()))
 	{
-        spdlog::error(parser.errors());
+        Logger::error(parser.errors());
         return false;
 	}
 
     m_module = std::make_unique<reshadefx::effect_module>(backend->module());
     if (m_module->techniques.empty() || m_module->techniques[0].passes.empty())
     {
-        spdlog::error("No techniques found: {}", filePath.string());
+        Logger::error("No techniques found: {}", filePath.string());
         return false;
     }
 
@@ -296,13 +296,13 @@ bool vkShade::ReshadeEffect::compile(VkExtent2D extent, std::filesystem::path fi
 
         if (!backend->assemble_code_for_entry_point(vsEntryPoint, vs_binary, vs_asm, errors))
         {
-            spdlog::error("Failed to assemble vertex shader: {}", errors);
+            Logger::error("Failed to assemble vertex shader: {}", errors);
             return false;
         }
 
         if (!backend->assemble_code_for_entry_point(psEntryPoint, ps_binary, ps_asm, errors))
         {
-            spdlog::error("Failed to assemble pixel shader: {}", errors);
+            Logger::error("Failed to assemble pixel shader: {}", errors);
             return false;
         }
 
@@ -584,7 +584,7 @@ void vkShade::ReshadeEffect::reflect_images()
             // Warn about lack of proper depth support
             if (!warnedAboutDepth && texIt != m_module->textures.end() && texIt->semantic == "DEPTH")
             {
-                spdlog::warn("Effect may require depth buffer access, which is not yet supported.");
+                Logger::warn("Effect may require depth buffer access, which is not yet supported.");
                 warnedAboutDepth = true;
             }
         }

--- a/src/vk/reshade_uniforms.cpp
+++ b/src/vk/reshade_uniforms.cpp
@@ -3,8 +3,6 @@
 #include <chrono>
 #include <effect_module.hpp>
 #include <glm/vec2.hpp>
-#include <spdlog/spdlog.h>
-
 #include "vk/buffer.hpp"
 #include "vk/reshade_runtime.hpp"
 

--- a/src/vk/sampler.cpp
+++ b/src/vk/sampler.cpp
@@ -3,14 +3,14 @@
 #include <utility>
 
 #include <effect_module.hpp>
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 
 #include "macros.hpp"
 
 vkShade::VulkanSampler::VulkanSampler(VulkanDevice& device, const reshadefx::sampler& samplerInfo)
     : VulkanObject(device)
 {
-    spdlog::trace("Creating sampler");
+    Logger::trace("Creating sampler");
 
     VkSamplerCreateInfo createInfo {
         .sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
@@ -33,7 +33,7 @@ vkShade::VulkanSampler::VulkanSampler(VulkanDevice& device, const reshadefx::sam
 
 vkShade::VulkanSampler::~VulkanSampler()
 {
-    spdlog::trace("Destroying sampler");
+    Logger::trace("Destroying sampler");
     m_device.dispatch.DestroySampler(m_device.handle, m_sampler, nullptr);
 }
 

--- a/src/vk/shader_module.cpp
+++ b/src/vk/shader_module.cpp
@@ -4,7 +4,7 @@
 #include <fstream>
 
 #include <magic_enum/magic_enum.hpp>
-#include <spdlog/spdlog.h>
+#include "core/logger.hpp"
 
 #include "hooks/hooks.hpp"
 
@@ -14,7 +14,7 @@ vkShade::ShaderModule::ShaderModule(VulkanDevice& device, const std::string& fil
 {
     if (!std::filesystem::exists(m_filePath) || !std::filesystem::is_regular_file(m_filePath))
     {
-        spdlog::error("File does not exist: {}", m_filePath);
+        Logger::error("File does not exist: {}", m_filePath);
         m_valid = false;
     }
 }
@@ -32,11 +32,11 @@ vkShade::ShaderModule::ShaderModule(VulkanDevice& device, std::span<const uint32
 
     if (result != VK_SUCCESS)
     {
-        spdlog::error("Failed to create shader module: {}", m_filePath);
+        Logger::error("Failed to create shader module: {}", m_filePath);
     }
 
     this->set_ready(true);
-    spdlog::trace("Created VkShaderModule from bytecode");
+    Logger::trace("Created VkShaderModule from bytecode");
 }
 
 bool vkShade::ShaderModule::load()
@@ -46,7 +46,7 @@ bool vkShade::ShaderModule::load()
 
     if (!file.is_open())
     {
-        spdlog::error("Failed to open file: {}", m_filePath);
+        Logger::error("Failed to open file: {}", m_filePath);
         return false;
     }
 
@@ -67,12 +67,12 @@ bool vkShade::ShaderModule::load()
 
     if (result != VK_SUCCESS)
     {
-        spdlog::error("Failed to create shader module: {}", m_filePath);
+        Logger::error("Failed to create shader module: {}", m_filePath);
         return false;
     }
 
     this->set_ready(true);
-    spdlog::trace("Created VkShaderModule from: {}", m_filePath);
+    Logger::trace("Created VkShaderModule from: {}", m_filePath);
     return true;
 }
 
@@ -81,6 +81,6 @@ vkShade::ShaderModule::~ShaderModule()
     if (m_module != VK_NULL_HANDLE)
     {
         m_device.dispatch.DestroyShaderModule(m_device.handle, m_module, nullptr);
-        spdlog::trace("Destroyed VkShaderModule");
+        Logger::trace("Destroyed VkShaderModule");
     }
 }

--- a/src/vk/swapchain.cpp
+++ b/src/vk/swapchain.cpp
@@ -3,10 +3,10 @@
 #include <imgui.h>
 #include <imgui_impl_vulkan.h>
 #include <magic_enum/magic_enum.hpp>
-#include <spdlog/spdlog.h>
 
 #include "config/config_manager.hpp"
 #include "core/event_bus.hpp"
+#include "core/logger.hpp"
 #include "core/service_locator.hpp"
 #include "hooks/hooks.hpp"
 #include "input/input_manager.hpp"
@@ -141,7 +141,7 @@ void vkShade::VulkanSwapchain::on_effects_changed(std::vector<std::string> effec
                             loadedEffects.push_back(effect);
                             found = true;
                         } catch (const std::runtime_error& exception) {
-                            spdlog::error(exception.what());
+                            Logger::error(exception.what());
                             error = true;
                         }
                         break;
@@ -151,7 +151,7 @@ void vkShade::VulkanSwapchain::on_effects_changed(std::vector<std::string> effec
         }
 
         if (!found && !error)
-            spdlog::warn("Unable to find effect: {}", effect);
+            Logger::warn("Unable to find effect: {}", effect);
     }
 
     auto& internalCfg = vkShade::Locator<vkShade::ConfigManager>::get().internal();

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -24,6 +24,7 @@ config_store_tests = executable('config_store_tests',
     catch2,
     glm,
     libconfig,
+    spdlog,
   ],
   include_directories : include_directories('../src')
 )


### PR DESCRIPTION
## Summary

Fix logging initialization races and isolate vkShade from the process-wide spdlog default logger.

## Problem

Logger setup previously happened from `vkCreateInstance`. Applications may create multiple Vulkan instances, potentially concurrently. Every initialization recreated the sinks and truncated `VKSHADE_LOG_FILE`, which could discard messages written by an earlier initialization.

In addition, Meson's static dependency preference may still resolve to a shared libspdlog when no static package is available. Vulkan layers loaded into the same process, such as MangoHud, then share spdlog's global registry and default logger.

Another layer may replace or clear the default logger after vkShade has configured it. Depending on layer initialization order, this redirects vkShade messages and can leave `VKSHADE_LOG_FILE` empty.

This was reproducible with ETS2 under Proton while MangoHud and vkShade were enabled together.

## Implementation

- Add a vkShade-owned logger exposed through `vkShade::log()`.
- Initialize it using thread-safe function-local static storage.
- Keep it independent from spdlog's process-wide registry and default logger.
- Route all vkShade diagnostics through the private logger.
- Open and truncate `VKSHADE_LOG_FILE` exactly once per loaded vkShade instance.
- Add the logger implementation to the layer and relevant test build targets.

The function-local initialization subsumes the earlier `std::call_once` approach while also isolating the logger from other Vulkan layers.

## Preserved behavior

- stderr logging remains enabled.
- `VKSHADE_LOG_FILE` remains optional.
- `VKSHADE_LOG_LEVEL` keeps its existing values and defaults.
- Log events continue to be flushed immediately.
- The log file is truncated when vkShade initializes rather than being appended across game launches.

## Validation

- Release build succeeds.
- Full test build passes all 5 tests.
- Runtime-tested with ETS2 under Proton together with MangoHud.
- `VKSHADE_LOG_FILE` is now populated correctly and contains vkShade diagnostics.