### PR TITLE
PoC: feat(gui): add developer diagnostics

### DIFF
--- a/src/core/diagnostics_state.hpp
+++ b/src/core/diagnostics_state.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <atomic>
+
+namespace vkShade
+{
+    struct DiagnosticsState
+    {
+        std::atomic_bool showPerformanceOverlay {false};
+
+        std::atomic_bool gpuTimingSupported {false};
+        std::atomic_bool gpuTimingValid {false};
+        std::atomic<double> totalGpuMilliseconds {0.0};
+        std::atomic<double> effectsGpuMilliseconds {0.0};
+    };
+} // namespace vkShade

--- a/src/core/diagnostics_state.hpp
+++ b/src/core/diagnostics_state.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 
 namespace vkShade
 {
@@ -12,5 +13,6 @@ namespace vkShade
         std::atomic_bool gpuTimingValid {false};
         std::atomic<double> totalGpuMilliseconds {0.0};
         std::atomic<double> effectsGpuMilliseconds {0.0};
+        std::atomic<uint32_t> gpuTimingSampleSequence {0};
     };
 } // namespace vkShade

--- a/src/core/rolling_statistics.hpp
+++ b/src/core/rolling_statistics.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <optional>
+
+namespace vkShade
+{
+    struct StatisticsSnapshot
+    {
+        double current {0.0};
+        double average {0.0};
+        double minimum {0.0};
+        double maximum {0.0};
+    };
+
+    template<std::size_t WindowSize>
+    class RollingStatistics
+    {
+        static_assert(WindowSize > 0);
+
+    public:
+        void add(double sample)
+        {
+            if (m_count == WindowSize)
+                m_sum -= m_samples[m_next];
+            else
+                ++m_count;
+
+            m_samples[m_next] = sample;
+            m_sum += sample;
+            m_current = sample;
+            m_next = (m_next + 1) % WindowSize;
+        }
+
+        void reset()
+        {
+            m_count = 0;
+            m_next = 0;
+            m_sum = 0.0;
+            m_current = 0.0;
+        }
+
+        [[nodiscard]]
+        std::optional<StatisticsSnapshot> snapshot() const
+        {
+            if (m_count == 0)
+                return std::nullopt;
+
+            const auto end = m_samples.begin() + static_cast<std::ptrdiff_t>(m_count);
+            const auto [minimum, maximum] = std::minmax_element(m_samples.begin(), end);
+            return StatisticsSnapshot {
+                .current = m_current,
+                .average = m_sum / static_cast<double>(m_count),
+                .minimum = *minimum,
+                .maximum = *maximum,
+            };
+        }
+
+    private:
+        std::array<double, WindowSize> m_samples {};
+        std::size_t m_count {0};
+        std::size_t m_next {0};
+        double m_sum {0.0};
+        double m_current {0.0};
+    };
+} // namespace vkShade

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -14,7 +14,8 @@
 #include "input_helpers.hpp"
 
 vkShade::GuiManager::GuiManager(VulkanDevice deviceContext, VkFormat swapchainFormat)
-    : m_mainWindow(deviceContext.imageTracker)
+    : m_mainWindow(deviceContext.diagnosticsState, deviceContext.imageTracker)
+    , m_diagnosticsOverlay(deviceContext.diagnosticsState)
 {
     m_device = deviceContext.handle;
 
@@ -178,6 +179,8 @@ void vkShade::GuiManager::update(float deltaTime, VkExtent2D swapchainExtent)
         // Last: Draw the cursor on top of everything
         this->draw_cursor();
     }
+
+    m_diagnosticsOverlay.render();
 
     ImGui::Render();
 }

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -14,6 +14,7 @@
 #include "input_helpers.hpp"
 
 vkShade::GuiManager::GuiManager(VulkanDevice deviceContext, VkFormat swapchainFormat)
+    : m_mainWindow(deviceContext.imageTracker)
 {
     m_device = deviceContext.handle;
 

--- a/src/gui/gui_manager.hpp
+++ b/src/gui/gui_manager.hpp
@@ -4,6 +4,7 @@
 
 #include "hooks/hooks.hpp"
 #include "windows/main_window.hpp"
+#include "windows/diagnostics_overlay.hpp"
 
 namespace vkShade
 {
@@ -30,6 +31,7 @@ namespace vkShade
         VkDescriptorPool m_descriptorPool;
 
         MainWindow m_mainWindow;
+        DiagnosticsOverlay m_diagnosticsOverlay;
 
         void draw_cursor();
 

--- a/src/gui/meson.build
+++ b/src/gui/meson.build
@@ -1,4 +1,5 @@
 libgui_source = [
+  'panels/buffer_panel.cpp',
   'panels/effects_panel.cpp',
   'panels/log_panel.cpp',
   'windows/about_window.cpp',

--- a/src/gui/meson.build
+++ b/src/gui/meson.build
@@ -3,6 +3,7 @@ libgui_source = [
   'panels/effects_panel.cpp',
   'panels/log_panel.cpp',
   'windows/about_window.cpp',
+  'windows/diagnostics_overlay.cpp',
   'windows/main_window.cpp',
   'gui_manager.cpp',
 ]

--- a/src/gui/panels/buffer_panel.cpp
+++ b/src/gui/panels/buffer_panel.cpp
@@ -192,6 +192,14 @@ void vkShade::BufferPanel::render()
         for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; ++row)
         {
             const TrackedImageSnapshot& image = *displayedImages[row];
+            const bool dimRow = hasPriority &&
+                                static_cast<size_t>(row) >= prioritizedCount;
+            if (dimRow)
+            {
+                ImGui::PushStyleColor(
+                    ImGuiCol_Text,
+                    ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+            }
             ImGui::TableNextRow();
 
             ImGui::TableSetColumnIndex(0);
@@ -223,6 +231,9 @@ void vkShade::BufferPanel::render()
                 ImGui::Text("%llu / %llu",
                             static_cast<unsigned long long>(image.lastSeenFrame),
                             static_cast<unsigned long long>(image.useCount));
+
+            if (dimRow)
+                ImGui::PopStyleColor();
         }
     }
 

--- a/src/gui/panels/buffer_panel.cpp
+++ b/src/gui/panels/buffer_panel.cpp
@@ -1,6 +1,8 @@
 #include "buffer_panel.hpp"
 
+#include <algorithm>
 #include <array>
+#include <iterator>
 #include <string>
 #include <utility>
 
@@ -104,9 +106,61 @@ void vkShade::BufferPanel::render()
         m_nextRefresh = ImGui::GetTime() + 0.25;
     }
 
-    ImGui::TextDisabled(
-        "%zu live render images. Application images appear after attachment use or with storage usage.",
-        m_trackedImages.size());
+    ImGui::TextUnformatted("Prioritize:");
+    ImGui::SameLine();
+    ImGui::Checkbox("Color", &m_prioritizeColorBuffers);
+    ImGui::SameLine();
+    ImGui::Checkbox("Depth/Stencil", &m_prioritizeDepthBuffers);
+    ImGui::SameLine();
+    ImGui::Checkbox("Storage", &m_prioritizeStorageBuffers);
+    ImGui::SameLine();
+    ImGui::Checkbox("Swapchain", &m_prioritizeSwapchainBuffers);
+    ImGui::SameLine();
+    ImGui::Checkbox("Internal", &m_prioritizeInternalBuffers);
+
+    const bool hasPriority = m_prioritizeColorBuffers ||
+                             m_prioritizeDepthBuffers ||
+                             m_prioritizeStorageBuffers ||
+                             m_prioritizeSwapchainBuffers ||
+                             m_prioritizeInternalBuffers;
+
+    std::vector<const TrackedImageSnapshot*> displayedImages;
+    displayedImages.reserve(m_trackedImages.size());
+    std::transform(
+        m_trackedImages.begin(), m_trackedImages.end(),
+        std::back_inserter(displayedImages),
+        [](const TrackedImageSnapshot& image) { return &image; });
+
+    size_t prioritizedCount = 0;
+    if (hasPriority)
+    {
+        const auto priorityEnd = std::stable_partition(
+            displayedImages.begin(), displayedImages.end(),
+            [this](const TrackedImageSnapshot* image)
+            {
+                return (m_prioritizeColorBuffers &&
+                        (image->usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) ||
+                       (m_prioritizeDepthBuffers &&
+                        (image->usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) ||
+                       (m_prioritizeStorageBuffers &&
+                        (image->usage & VK_IMAGE_USAGE_STORAGE_BIT)) ||
+                       (m_prioritizeSwapchainBuffers &&
+                        image->origin == TrackedImageOrigin::Swapchain) ||
+                       (m_prioritizeInternalBuffers &&
+                        image->origin == TrackedImageOrigin::VkShade);
+            });
+        prioritizedCount = std::distance(displayedImages.begin(), priorityEnd);
+
+        ImGui::TextDisabled(
+            "%zu of %zu tracked images prioritized; none are hidden.",
+            prioritizedCount, m_trackedImages.size());
+    }
+    else
+    {
+        ImGui::TextDisabled(
+            "%zu tracked images. Select categories to prioritize them without hiding others.",
+            m_trackedImages.size());
+    }
     ImGui::Separator();
 
     constexpr ImGuiTableFlags tableFlags =
@@ -132,12 +186,12 @@ void vkShade::BufferPanel::render()
     ImGui::TableHeadersRow();
 
     ImGuiListClipper clipper;
-    clipper.Begin(static_cast<int>(m_trackedImages.size()));
+    clipper.Begin(static_cast<int>(displayedImages.size()));
     while (clipper.Step())
     {
         for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; ++row)
         {
-            const TrackedImageSnapshot& image = m_trackedImages[row];
+            const TrackedImageSnapshot& image = *displayedImages[row];
             ImGui::TableNextRow();
 
             ImGui::TableSetColumnIndex(0);

--- a/src/gui/panels/buffer_panel.cpp
+++ b/src/gui/panels/buffer_panel.cpp
@@ -1,0 +1,176 @@
+#include "buffer_panel.hpp"
+
+#include <array>
+#include <string>
+#include <utility>
+
+#include <imgui.h>
+#include <magic_enum/magic_enum.hpp>
+
+#include "core/logger.hpp"
+
+namespace
+{
+    const char* image_origin_name(vkShade::TrackedImageOrigin origin)
+    {
+        switch (origin)
+        {
+            case vkShade::TrackedImageOrigin::Application: return "Application";
+            case vkShade::TrackedImageOrigin::Swapchain: return "Swapchain";
+            case vkShade::TrackedImageOrigin::VkShade: return "vkShade";
+        }
+        return "Unknown";
+    }
+
+    bool has_observation(vkShade::ImageObservation observations,
+                         vkShade::ImageObservation test)
+    {
+        return (static_cast<uint8_t>(observations) & static_cast<uint8_t>(test)) != 0;
+    }
+
+    const char* image_role_name(const vkShade::TrackedImageSnapshot& image)
+    {
+        if (image.origin == vkShade::TrackedImageOrigin::Swapchain)
+            return "Swapchain";
+        if (has_observation(image.observations,
+                            vkShade::ImageObservation::DepthStencilAttachment))
+            return "Depth/stencil attachment";
+        if (has_observation(image.observations,
+                            vkShade::ImageObservation::ColorAttachment))
+            return "Color attachment";
+        if (image.observedAspects & (VK_IMAGE_ASPECT_DEPTH_BIT |
+                                     VK_IMAGE_ASPECT_STENCIL_BIT))
+            return "Depth/stencil attachment";
+        if (image.observedAspects & VK_IMAGE_ASPECT_COLOR_BIT)
+            return "Color attachment";
+        if (image.usage & VK_IMAGE_USAGE_STORAGE_BIT)
+            return "Storage capable";
+        if (image.usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
+            return "Depth/stencil capable";
+        if (image.usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
+            return "Color capable";
+        if (image.usage & VK_IMAGE_USAGE_SAMPLED_BIT)
+            return "Sampled image";
+        return "Image";
+    }
+
+    std::string image_usage_string(VkImageUsageFlags usage)
+    {
+        struct UsageName
+        {
+            VkImageUsageFlagBits flag;
+            const char* name;
+        };
+        constexpr std::array usageNames = {
+            UsageName {VK_IMAGE_USAGE_TRANSFER_SRC_BIT, "Transfer src"},
+            UsageName {VK_IMAGE_USAGE_TRANSFER_DST_BIT, "Transfer dst"},
+            UsageName {VK_IMAGE_USAGE_SAMPLED_BIT, "Sampled"},
+            UsageName {VK_IMAGE_USAGE_STORAGE_BIT, "Storage"},
+            UsageName {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, "Color attachment"},
+            UsageName {VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, "Depth/stencil"},
+            UsageName {VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT, "Transient"},
+            UsageName {VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, "Input attachment"},
+        };
+
+        std::string result;
+        for (const auto& entry : usageNames)
+        {
+            if (!(usage & entry.flag))
+                continue;
+            if (!result.empty())
+                result.append(", ");
+            result.append(entry.name);
+        }
+        return result.empty() ? "None" : result;
+    }
+}
+
+vkShade::BufferPanel::BufferPanel(std::shared_ptr<ImageTracker> imageTracker)
+    : m_imageTracker(std::move(imageTracker))
+{}
+
+void vkShade::BufferPanel::render()
+{
+    if (m_trackedImages.empty() || ImGui::GetTime() >= m_nextRefresh)
+    {
+        try
+        {
+            m_trackedImages = m_imageTracker->snapshot();
+        }
+        catch (const std::exception& exception)
+        {
+            Logger::warn("Unable to refresh buffer diagnostics: {}", exception.what());
+        }
+        m_nextRefresh = ImGui::GetTime() + 0.25;
+    }
+
+    ImGui::TextDisabled(
+        "%zu live render images. Application images appear after attachment use or with storage usage.",
+        m_trackedImages.size());
+    ImGui::Separator();
+
+    constexpr ImGuiTableFlags tableFlags =
+        ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+        ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable |
+        ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY |
+        ImGuiTableFlags_SizingFixedFit;
+
+    if (!ImGui::BeginTable("TrackedBuffers", 10, tableFlags, ImVec2(0, 0)))
+        return;
+
+    ImGui::TableSetupScrollFreeze(2, 1);
+    ImGui::TableSetupColumn("ID", ImGuiTableColumnFlags_WidthFixed);
+    ImGui::TableSetupColumn("Role", ImGuiTableColumnFlags_WidthFixed, 170.0f);
+    ImGui::TableSetupColumn("Origin", ImGuiTableColumnFlags_WidthFixed);
+    ImGui::TableSetupColumn("Extent", ImGuiTableColumnFlags_WidthFixed);
+    ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed);
+    ImGui::TableSetupColumn("Format", ImGuiTableColumnFlags_WidthFixed, 190.0f);
+    ImGui::TableSetupColumn("Samples", ImGuiTableColumnFlags_WidthFixed);
+    ImGui::TableSetupColumn("Mips / Layers", ImGuiTableColumnFlags_WidthFixed);
+    ImGui::TableSetupColumn("Usage", ImGuiTableColumnFlags_WidthFixed, 360.0f);
+    ImGui::TableSetupColumn("Last frame / Observations", ImGuiTableColumnFlags_WidthFixed);
+    ImGui::TableHeadersRow();
+
+    ImGuiListClipper clipper;
+    clipper.Begin(static_cast<int>(m_trackedImages.size()));
+    while (clipper.Step())
+    {
+        for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; ++row)
+        {
+            const TrackedImageSnapshot& image = m_trackedImages[row];
+            ImGui::TableNextRow();
+
+            ImGui::TableSetColumnIndex(0);
+            ImGui::Text("%llu", static_cast<unsigned long long>(image.id));
+            ImGui::TableSetColumnIndex(1);
+            ImGui::TextUnformatted(image_role_name(image));
+            ImGui::TableSetColumnIndex(2);
+            ImGui::TextUnformatted(image_origin_name(image.origin));
+            ImGui::TableSetColumnIndex(3);
+            ImGui::Text("%u x %u x %u", image.extent.width,
+                        image.extent.height, image.extent.depth);
+            ImGui::TableSetColumnIndex(4);
+            const auto typeName = magic_enum::enum_name(image.type);
+            ImGui::TextUnformatted(typeName.data(), typeName.data() + typeName.size());
+            ImGui::TableSetColumnIndex(5);
+            const auto formatName = magic_enum::enum_name(image.format);
+            ImGui::TextUnformatted(formatName.data(), formatName.data() + formatName.size());
+            ImGui::TableSetColumnIndex(6);
+            ImGui::Text("%u", static_cast<uint32_t>(image.samples));
+            ImGui::TableSetColumnIndex(7);
+            ImGui::Text("%u / %u", image.mipLevels, image.arrayLayers);
+            ImGui::TableSetColumnIndex(8);
+            const std::string usage = image_usage_string(image.usage);
+            ImGui::TextUnformatted(usage.c_str());
+            ImGui::TableSetColumnIndex(9);
+            if (image.useCount == 0)
+                ImGui::TextUnformatted("- / -");
+            else
+                ImGui::Text("%llu / %llu",
+                            static_cast<unsigned long long>(image.lastSeenFrame),
+                            static_cast<unsigned long long>(image.useCount));
+        }
+    }
+
+    ImGui::EndTable();
+}

--- a/src/gui/panels/buffer_panel.hpp
+++ b/src/gui/panels/buffer_panel.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "panel.hpp"
+
+#include <memory>
+#include <vector>
+
+#include "vk/image_tracker.hpp"
+
+namespace vkShade
+{
+    class BufferPanel : public GuiPanel
+    {
+    public:
+        explicit BufferPanel(std::shared_ptr<ImageTracker> imageTracker);
+
+        void render() override;
+
+    private:
+        std::shared_ptr<ImageTracker> m_imageTracker;
+        std::vector<TrackedImageSnapshot> m_trackedImages;
+        double m_nextRefresh = 0.0;
+    };
+} // namespace vkShade

--- a/src/gui/panels/buffer_panel.hpp
+++ b/src/gui/panels/buffer_panel.hpp
@@ -20,5 +20,10 @@ namespace vkShade
         std::shared_ptr<ImageTracker> m_imageTracker;
         std::vector<TrackedImageSnapshot> m_trackedImages;
         double m_nextRefresh = 0.0;
+        bool m_prioritizeColorBuffers = false;
+        bool m_prioritizeDepthBuffers = false;
+        bool m_prioritizeStorageBuffers = false;
+        bool m_prioritizeSwapchainBuffers = false;
+        bool m_prioritizeInternalBuffers = false;
     };
 } // namespace vkShade

--- a/src/gui/windows/diagnostics_overlay.cpp
+++ b/src/gui/windows/diagnostics_overlay.cpp
@@ -1,0 +1,101 @@
+#include "diagnostics_overlay.hpp"
+
+#include <algorithm>
+
+#include <imgui.h>
+
+vkShade::DiagnosticsOverlay::DiagnosticsOverlay(
+    std::shared_ptr<DiagnosticsState> diagnosticsState)
+    : m_diagnosticsState(std::move(diagnosticsState))
+{}
+
+void vkShade::DiagnosticsOverlay::render()
+{
+    const bool showPerformance =
+        m_diagnosticsState->showPerformanceOverlay.load(std::memory_order_relaxed);
+    if (!showPerformance)
+        return;
+
+    const ImGuiViewport* viewport = ImGui::GetMainViewport();
+    constexpr float margin = 12.0f;
+    ImGui::SetNextWindowPos(
+        ImVec2(viewport->WorkPos.x + viewport->WorkSize.x - margin,
+               viewport->WorkPos.y + margin),
+        ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+    ImGui::SetNextWindowBgAlpha(0.78f);
+
+    constexpr ImGuiWindowFlags flags =
+        ImGuiWindowFlags_NoDecoration |
+        ImGuiWindowFlags_AlwaysAutoResize |
+        ImGuiWindowFlags_NoSavedSettings |
+        ImGuiWindowFlags_NoFocusOnAppearing |
+        ImGuiWindowFlags_NoNav |
+        ImGuiWindowFlags_NoInputs;
+
+    if (ImGui::Begin("vkShade HUD###diagnostics-overlay", nullptr, flags))
+    {
+        ImGui::TextUnformatted("vkShade");
+        ImGui::Separator();
+
+        render_performance();
+    }
+    ImGui::End();
+}
+
+void vkShade::DiagnosticsOverlay::render_performance()
+{
+    if (!m_diagnosticsState->gpuTimingSupported.load(std::memory_order_relaxed))
+    {
+        reset_performance_samples();
+        ImGui::TextDisabled("GPU timing unavailable");
+        return;
+    }
+
+    if (!m_diagnosticsState->gpuTimingValid.load(std::memory_order_acquire))
+    {
+        reset_performance_samples();
+        ImGui::TextDisabled("GPU timing: waiting for sample");
+        return;
+    }
+
+    const uint32_t sample =
+        m_diagnosticsState->gpuTimingSampleSequence.load(std::memory_order_acquire);
+    if (sample != m_lastGpuTimingSample)
+    {
+        const double total =
+            m_diagnosticsState->totalGpuMilliseconds.load(std::memory_order_relaxed);
+        const double effects =
+            m_diagnosticsState->effectsGpuMilliseconds.load(std::memory_order_relaxed);
+        m_totalGpuStatistics.add(total);
+        m_effectsGpuStatistics.add(effects);
+        m_otherGpuStatistics.add(std::max(0.0, total - effects));
+        m_lastGpuTimingSample = sample;
+    }
+
+    const auto total = m_totalGpuStatistics.snapshot();
+    const auto effects = m_effectsGpuStatistics.snapshot();
+    const auto other = m_otherGpuStatistics.snapshot();
+    if (!total || !effects || !other)
+    {
+        ImGui::TextDisabled("GPU timing: waiting for sample");
+        return;
+    }
+
+    ImGui::TextDisabled("                 cur      avg      min      max");
+    ImGui::Text("vkShade GPU  %7.3f  %7.3f  %7.3f  %7.3f ms",
+                total->current, total->average, total->minimum, total->maximum);
+    ImGui::TextDisabled("Effects      %7.3f  %7.3f  %7.3f  %7.3f ms",
+                        effects->current, effects->average,
+                        effects->minimum, effects->maximum);
+    ImGui::TextDisabled("Other        %7.3f  %7.3f  %7.3f  %7.3f ms",
+                        other->current, other->average, other->minimum, other->maximum);
+}
+
+void vkShade::DiagnosticsOverlay::reset_performance_samples()
+{
+    m_totalGpuStatistics.reset();
+    m_effectsGpuStatistics.reset();
+    m_otherGpuStatistics.reset();
+    m_lastGpuTimingSample =
+        m_diagnosticsState->gpuTimingSampleSequence.load(std::memory_order_relaxed);
+}

--- a/src/gui/windows/diagnostics_overlay.hpp
+++ b/src/gui/windows/diagnostics_overlay.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "core/diagnostics_state.hpp"
+#include "core/rolling_statistics.hpp"
+
+namespace vkShade
+{
+    class DiagnosticsOverlay
+    {
+    public:
+        explicit DiagnosticsOverlay(std::shared_ptr<DiagnosticsState> diagnosticsState);
+
+        void render();
+
+    private:
+        static constexpr std::size_t TimingWindowSize = 120;
+
+        void render_performance();
+        void reset_performance_samples();
+
+        std::shared_ptr<DiagnosticsState> m_diagnosticsState;
+        RollingStatistics<TimingWindowSize> m_totalGpuStatistics;
+        RollingStatistics<TimingWindowSize> m_effectsGpuStatistics;
+        RollingStatistics<TimingWindowSize> m_otherGpuStatistics;
+        uint32_t m_lastGpuTimingSample {0};
+    };
+} // namespace vkShade

--- a/src/gui/windows/main_window.cpp
+++ b/src/gui/windows/main_window.cpp
@@ -3,8 +3,10 @@
 #include "config/config_manager.hpp"
 #include "core/service_locator.hpp"
 
-vkShade::MainWindow::MainWindow(std::shared_ptr<ImageTracker> imageTracker)
+vkShade::MainWindow::MainWindow(std::shared_ptr<DiagnosticsState> diagnosticsState,
+                                std::shared_ptr<ImageTracker> imageTracker)
     : m_preset(vkShade::Locator<ConfigManager>::get().preset()),
+      m_diagnosticsState(std::move(diagnosticsState)),
       m_bufferPanel(std::move(imageTracker))
 {}
 
@@ -85,6 +87,19 @@ void vkShade::MainWindow::render_menu_bar()
             if (ImGui::MenuItem("Close"))
             {
                 m_visible = false;
+            }
+
+            ImGui::EndMenu();
+        }
+
+        if (ImGui::BeginMenu("View"))
+        {
+            bool showPerformance = m_diagnosticsState->showPerformanceOverlay.load(
+                std::memory_order_relaxed);
+            if (ImGui::MenuItem("Performance overlay", nullptr, &showPerformance))
+            {
+                m_diagnosticsState->showPerformanceOverlay.store(
+                    showPerformance, std::memory_order_relaxed);
             }
 
             ImGui::EndMenu();

--- a/src/gui/windows/main_window.cpp
+++ b/src/gui/windows/main_window.cpp
@@ -3,8 +3,9 @@
 #include "config/config_manager.hpp"
 #include "core/service_locator.hpp"
 
-vkShade::MainWindow::MainWindow()
-    : m_preset(vkShade::Locator<ConfigManager>::get().preset())
+vkShade::MainWindow::MainWindow(std::shared_ptr<ImageTracker> imageTracker)
+    : m_preset(vkShade::Locator<ConfigManager>::get().preset()),
+      m_bufferPanel(std::move(imageTracker))
 {}
 
 void vkShade::MainWindow::render()
@@ -24,6 +25,12 @@ void vkShade::MainWindow::render()
             if (ImGui::BeginTabItem("Effects###effects"))
             {
                 m_effectsPanel.render();
+                ImGui::EndTabItem();
+            }
+
+            if (ImGui::BeginTabItem("Buffers###buffers"))
+            {
+                m_bufferPanel.render();
                 ImGui::EndTabItem();
             }
 

--- a/src/gui/windows/main_window.hpp
+++ b/src/gui/windows/main_window.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <memory>
+
 #include <imgui.h>
 
 #include "config/config_store.hpp"
+#include "../panels/buffer_panel.hpp"
 #include "../panels/effects_panel.hpp"
 #include "../panels/log_panel.hpp"
 #include "../window.hpp"
@@ -14,7 +17,7 @@ namespace vkShade
     class MainWindow : public GuiWindow
     {
     public:
-        MainWindow();
+        explicit MainWindow(std::shared_ptr<ImageTracker> imageTracker);
 
         void render() override;
 
@@ -23,6 +26,7 @@ namespace vkShade
 
         // Panels
         EffectsPanel m_effectsPanel;
+        BufferPanel  m_bufferPanel;
         LogPanel     m_logPanel;
 
         // Sub-windows

--- a/src/gui/windows/main_window.hpp
+++ b/src/gui/windows/main_window.hpp
@@ -5,6 +5,7 @@
 #include <imgui.h>
 
 #include "config/config_store.hpp"
+#include "core/diagnostics_state.hpp"
 #include "../panels/buffer_panel.hpp"
 #include "../panels/effects_panel.hpp"
 #include "../panels/log_panel.hpp"
@@ -17,12 +18,14 @@ namespace vkShade
     class MainWindow : public GuiWindow
     {
     public:
-        explicit MainWindow(std::shared_ptr<ImageTracker> imageTracker);
+        MainWindow(std::shared_ptr<DiagnosticsState> diagnosticsState,
+                   std::shared_ptr<ImageTracker> imageTracker);
 
         void render() override;
 
     private:
         ConfigStore& m_preset;
+        std::shared_ptr<DiagnosticsState> m_diagnosticsState;
 
         // Panels
         EffectsPanel m_effectsPanel;

--- a/src/hooks/hooks.hpp
+++ b/src/hooks/hooks.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
 #include <assert.h>
+#include <memory>
 #include <shared_mutex>
 #include <unordered_map>
 
 #include <vk_mem_alloc.h>
 #include <vulkan/utility/vk_dispatch_table.h>
 #include <vulkan/vulkan_core.h>
+
+#include "vk/image_tracker.hpp"
 
 #undef VK_LAYER_EXPORT
 #if defined(__GNUC__) && __GNUC__ >= 4
@@ -34,6 +37,7 @@ struct VulkanDevice
     VkQueue       queue;
     uint32_t      queueFamilyIndex;
     VkCommandPool commandPool;
+    std::shared_ptr<vkShade::ImageTracker> imageTracker;
 };
 
 inline void* const dispatch_key_from_handle(const void* handle)
@@ -86,3 +90,33 @@ VkResult VKAPI_CALL vkShade_QueuePresentKHR(VkQueue queue, const VkPresentInfoKH
 VkResult VKAPI_CALL vkShade_AllocateCommandBuffers(VkDevice                           device,
                                                    const VkCommandBufferAllocateInfo* pAllocateInfo,
                                                    VkCommandBuffer*                   pCommandBuffers);
+
+VkResult VKAPI_CALL vkShade_CreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
+                                        const VkAllocationCallbacks* pAllocator, VkImage* pImage);
+void VKAPI_CALL vkShade_DestroyImage(VkDevice device, VkImage image,
+                                     const VkAllocationCallbacks* pAllocator);
+VkResult VKAPI_CALL vkShade_CreateImageView(VkDevice device,
+                                            const VkImageViewCreateInfo* pCreateInfo,
+                                            const VkAllocationCallbacks* pAllocator,
+                                            VkImageView* pView);
+void VKAPI_CALL vkShade_DestroyImageView(VkDevice device, VkImageView imageView,
+                                         const VkAllocationCallbacks* pAllocator);
+VkResult VKAPI_CALL vkShade_CreateFramebuffer(VkDevice device,
+                                              const VkFramebufferCreateInfo* pCreateInfo,
+                                              const VkAllocationCallbacks* pAllocator,
+                                              VkFramebuffer* pFramebuffer);
+void VKAPI_CALL vkShade_DestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer,
+                                           const VkAllocationCallbacks* pAllocator);
+void VKAPI_CALL vkShade_CmdBeginRendering(VkCommandBuffer commandBuffer,
+                                          const VkRenderingInfo* pRenderingInfo);
+void VKAPI_CALL vkShade_CmdBeginRenderingKHR(VkCommandBuffer commandBuffer,
+                                             const VkRenderingInfo* pRenderingInfo);
+void VKAPI_CALL vkShade_CmdBeginRenderPass(VkCommandBuffer commandBuffer,
+                                           const VkRenderPassBeginInfo* pRenderPassBegin,
+                                           VkSubpassContents contents);
+void VKAPI_CALL vkShade_CmdBeginRenderPass2(VkCommandBuffer commandBuffer,
+                                            const VkRenderPassBeginInfo* pRenderPassBegin,
+                                            const VkSubpassBeginInfo* pSubpassBeginInfo);
+void VKAPI_CALL vkShade_CmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer,
+                                               const VkRenderPassBeginInfo* pRenderPassBegin,
+                                               const VkSubpassBeginInfo* pSubpassBeginInfo);

--- a/src/hooks/hooks.hpp
+++ b/src/hooks/hooks.hpp
@@ -9,6 +9,7 @@
 #include <vulkan/utility/vk_dispatch_table.h>
 #include <vulkan/vulkan_core.h>
 
+#include "core/diagnostics_state.hpp"
 #include "vk/image_tracker.hpp"
 
 #undef VK_LAYER_EXPORT
@@ -36,7 +37,10 @@ struct VulkanDevice
 
     VkQueue       queue;
     uint32_t      queueFamilyIndex;
+    uint32_t      timestampValidBits {0};
+    float         timestampPeriod {0.0f};
     VkCommandPool commandPool;
+    std::shared_ptr<vkShade::DiagnosticsState> diagnosticsState;
     std::shared_ptr<vkShade::ImageTracker> imageTracker;
 };
 

--- a/src/hooks/hooks_device.cpp
+++ b/src/hooks/hooks_device.cpp
@@ -102,6 +102,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
     thisDevice.handle = *pDevice;
     thisDevice.physicalDevice = physicalDevice;
     thisDevice.instance = thisInstance.handle;
+    thisDevice.imageTracker = std::make_shared<vkShade::ImageTracker>();
 
     // Initialize dispatch table
     vkuInitDeviceDispatchTable(*pDevice, &thisDevice.dispatch, gdpa);

--- a/src/hooks/hooks_device.cpp
+++ b/src/hooks/hooks_device.cpp
@@ -102,7 +102,12 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
     thisDevice.handle = *pDevice;
     thisDevice.physicalDevice = physicalDevice;
     thisDevice.instance = thisInstance.handle;
+    thisDevice.diagnosticsState = std::make_shared<vkShade::DiagnosticsState>();
     thisDevice.imageTracker = std::make_shared<vkShade::ImageTracker>();
+
+    VkPhysicalDeviceProperties physicalDeviceProperties {};
+    thisInstance.dispatch.GetPhysicalDeviceProperties(physicalDevice, &physicalDeviceProperties);
+    thisDevice.timestampPeriod = physicalDeviceProperties.limits.timestampPeriod;
 
     // Initialize dispatch table
     vkuInitDeviceDispatchTable(*pDevice, &thisDevice.dispatch, gdpa);
@@ -127,6 +132,8 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
 				vkShade::Logger::warn("Selected graphics queue has a low priority: {}", pCreateInfo->pQueueCreateInfos[i].pQueuePriorities[0]);
 
 			thisDevice.queueFamilyIndex = queueInfo.queueFamilyIndex;
+            thisDevice.timestampValidBits =
+                queueProperties[thisDevice.queueFamilyIndex].timestampValidBits;
             thisDevice.dispatch.GetDeviceQueue(thisDevice.handle, thisDevice.queueFamilyIndex, 0, &thisDevice.queue);
 
             VkCommandPoolCreateInfo commandPoolCreateInfo;
@@ -140,6 +147,10 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
             break;
 		}
 	}
+
+    thisDevice.diagnosticsState->gpuTimingSupported.store(
+        thisDevice.timestampValidBits > 0 && thisDevice.timestampPeriod > 0.0f,
+        std::memory_order_relaxed);
 
     // Initialize the Vulkan Memory Allocator
     {

--- a/src/hooks/hooks_entrypoints.cpp
+++ b/src/hooks/hooks_entrypoints.cpp
@@ -36,6 +36,17 @@ VK_LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL vkShade_GetDeviceProcAddr(VkDevice
     GETPROCADDR(QueuePresentKHR);
 
     GETPROCADDR(AllocateCommandBuffers);
+    GETPROCADDR(CreateImage);
+    GETPROCADDR(DestroyImage);
+    GETPROCADDR(CreateImageView);
+    GETPROCADDR(DestroyImageView);
+    GETPROCADDR(CreateFramebuffer);
+    GETPROCADDR(DestroyFramebuffer);
+    GETPROCADDR(CmdBeginRendering);
+    GETPROCADDR(CmdBeginRenderingKHR);
+    GETPROCADDR(CmdBeginRenderPass);
+    GETPROCADDR(CmdBeginRenderPass2);
+    GETPROCADDR(CmdBeginRenderPass2KHR);
 
     // Acquire a reader lock
     {

--- a/src/hooks/hooks_resources.cpp
+++ b/src/hooks/hooks_resources.cpp
@@ -1,0 +1,239 @@
+#include "hooks.hpp"
+
+#include <exception>
+
+#include "core/logger.hpp"
+
+namespace
+{
+    template<typename Function>
+    void track_safely(Function&& function)
+    {
+        try
+        {
+            function();
+        }
+        catch (const std::exception& exception)
+        {
+            vkShade::Logger::warn("Buffer tracking failed: {}", exception.what());
+        }
+        catch (...)
+        {
+            vkShade::Logger::warn("Buffer tracking failed with an unknown error");
+        }
+    }
+
+    void observe_rendering(VulkanDevice& device, const VkRenderingInfo* renderingInfo)
+    {
+        if (renderingInfo == nullptr)
+            return;
+
+        track_safely([&]
+        {
+            for (uint32_t i = 0; i < renderingInfo->colorAttachmentCount; ++i)
+            {
+                const VkRenderingAttachmentInfo& attachment =
+                    renderingInfo->pColorAttachments[i];
+                device.imageTracker->observe_view(
+                    attachment.imageView,
+                    vkShade::ImageObservation::ColorAttachment);
+                device.imageTracker->observe_view(
+                    attachment.resolveImageView,
+                    vkShade::ImageObservation::ColorAttachment);
+            }
+
+            if (renderingInfo->pDepthAttachment != nullptr)
+            {
+                device.imageTracker->observe_view(
+                    renderingInfo->pDepthAttachment->imageView,
+                    vkShade::ImageObservation::DepthStencilAttachment);
+                device.imageTracker->observe_view(
+                    renderingInfo->pDepthAttachment->resolveImageView,
+                    vkShade::ImageObservation::DepthStencilAttachment);
+            }
+
+            if (renderingInfo->pStencilAttachment != nullptr)
+            {
+                device.imageTracker->observe_view(
+                    renderingInfo->pStencilAttachment->imageView,
+                    vkShade::ImageObservation::DepthStencilAttachment);
+                device.imageTracker->observe_view(
+                    renderingInfo->pStencilAttachment->resolveImageView,
+                    vkShade::ImageObservation::DepthStencilAttachment);
+            }
+        });
+    }
+
+    const VkRenderPassAttachmentBeginInfo* find_attachment_begin_info(
+        const VkRenderPassBeginInfo& renderPassInfo)
+    {
+        auto* next = static_cast<const VkBaseInStructure*>(renderPassInfo.pNext);
+        while (next != nullptr)
+        {
+            if (next->sType == VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO)
+            {
+                return reinterpret_cast<const VkRenderPassAttachmentBeginInfo*>(next);
+            }
+            next = next->pNext;
+        }
+        return nullptr;
+    }
+
+    void observe_render_pass(VulkanDevice& device,
+                             const VkRenderPassBeginInfo* renderPassInfo)
+    {
+        if (renderPassInfo == nullptr)
+            return;
+
+        track_safely([&]
+        {
+            const VkRenderPassAttachmentBeginInfo* attachmentInfo =
+                find_attachment_begin_info(*renderPassInfo);
+            if (attachmentInfo == nullptr)
+            {
+                device.imageTracker->observe_framebuffer(renderPassInfo->framebuffer);
+                return;
+            }
+
+            if (attachmentInfo->pAttachments == nullptr)
+                return;
+
+            for (uint32_t i = 0; i < attachmentInfo->attachmentCount; ++i)
+            {
+                device.imageTracker->observe_view(
+                    attachmentInfo->pAttachments[i],
+                    vkShade::ImageObservation::None);
+            }
+        });
+    }
+}
+
+VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateImage(
+    VkDevice device, const VkImageCreateInfo* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator, VkImage* pImage)
+{
+    auto& thisDevice = get_device_from_handle(device);
+    const VkResult result = thisDevice.dispatch.CreateImage(
+        device, pCreateInfo, pAllocator, pImage);
+
+    if (result == VK_SUCCESS)
+    {
+        track_safely([&]
+        {
+            thisDevice.imageTracker->register_image(
+                *pImage, *pCreateInfo, vkShade::TrackedImageOrigin::Application);
+        });
+    }
+    return result;
+}
+
+VK_LAYER_EXPORT void VKAPI_CALL vkShade_DestroyImage(
+    VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator)
+{
+    auto& thisDevice = get_device_from_handle(device);
+    track_safely([&] { thisDevice.imageTracker->unregister_image(image); });
+    thisDevice.dispatch.DestroyImage(device, image, pAllocator);
+}
+
+VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateImageView(
+    VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator, VkImageView* pView)
+{
+    auto& thisDevice = get_device_from_handle(device);
+    const VkResult result = thisDevice.dispatch.CreateImageView(
+        device, pCreateInfo, pAllocator, pView);
+
+    if (result == VK_SUCCESS)
+    {
+        track_safely([&]
+        {
+            thisDevice.imageTracker->register_view(
+                *pView, pCreateInfo->image, pCreateInfo->subresourceRange);
+        });
+    }
+    return result;
+}
+
+VK_LAYER_EXPORT void VKAPI_CALL vkShade_DestroyImageView(
+    VkDevice device, VkImageView imageView, const VkAllocationCallbacks* pAllocator)
+{
+    auto& thisDevice = get_device_from_handle(device);
+    track_safely([&] { thisDevice.imageTracker->unregister_view(imageView); });
+    thisDevice.dispatch.DestroyImageView(device, imageView, pAllocator);
+}
+
+VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateFramebuffer(
+    VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer)
+{
+    auto& thisDevice = get_device_from_handle(device);
+    const VkResult result = thisDevice.dispatch.CreateFramebuffer(
+        device, pCreateInfo, pAllocator, pFramebuffer);
+
+    if (result == VK_SUCCESS)
+    {
+        track_safely([&]
+        {
+            thisDevice.imageTracker->register_framebuffer(
+                *pFramebuffer, pCreateInfo->attachmentCount, pCreateInfo->pAttachments);
+        });
+    }
+    return result;
+}
+
+VK_LAYER_EXPORT void VKAPI_CALL vkShade_DestroyFramebuffer(
+    VkDevice device, VkFramebuffer framebuffer,
+    const VkAllocationCallbacks* pAllocator)
+{
+    auto& thisDevice = get_device_from_handle(device);
+    track_safely([&]
+    {
+        thisDevice.imageTracker->unregister_framebuffer(framebuffer);
+    });
+    thisDevice.dispatch.DestroyFramebuffer(device, framebuffer, pAllocator);
+}
+
+VK_LAYER_EXPORT void VKAPI_CALL vkShade_CmdBeginRendering(
+    VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo)
+{
+    auto& thisDevice = get_device_from_handle(commandBuffer);
+    observe_rendering(thisDevice, pRenderingInfo);
+    thisDevice.dispatch.CmdBeginRendering(commandBuffer, pRenderingInfo);
+}
+
+VK_LAYER_EXPORT void VKAPI_CALL vkShade_CmdBeginRenderingKHR(
+    VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo)
+{
+    auto& thisDevice = get_device_from_handle(commandBuffer);
+    observe_rendering(thisDevice, pRenderingInfo);
+    thisDevice.dispatch.CmdBeginRenderingKHR(commandBuffer, pRenderingInfo);
+}
+
+VK_LAYER_EXPORT void VKAPI_CALL vkShade_CmdBeginRenderPass(
+    VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+    VkSubpassContents contents)
+{
+    auto& thisDevice = get_device_from_handle(commandBuffer);
+    observe_render_pass(thisDevice, pRenderPassBegin);
+    thisDevice.dispatch.CmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents);
+}
+
+VK_LAYER_EXPORT void VKAPI_CALL vkShade_CmdBeginRenderPass2(
+    VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+    const VkSubpassBeginInfo* pSubpassBeginInfo)
+{
+    auto& thisDevice = get_device_from_handle(commandBuffer);
+    observe_render_pass(thisDevice, pRenderPassBegin);
+    thisDevice.dispatch.CmdBeginRenderPass2(
+        commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
+}
+
+VK_LAYER_EXPORT void VKAPI_CALL vkShade_CmdBeginRenderPass2KHR(
+    VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+    const VkSubpassBeginInfo* pSubpassBeginInfo)
+{
+    auto& thisDevice = get_device_from_handle(commandBuffer);
+    observe_render_pass(thisDevice, pRenderPassBegin);
+    thisDevice.dispatch.CmdBeginRenderPass2KHR(
+        commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
+}

--- a/src/hooks/hooks_swapchain.cpp
+++ b/src/hooks/hooks_swapchain.cpp
@@ -36,7 +36,8 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateSwapchainKHR(VkDevice         
     // Create and store swapchain object
     {
         std::lock_guard<std::mutex> lock(g_swapchainMutex);
-        g_swapchains[*pSwapchain] = std::make_unique<vkShade::VulkanSwapchain>(thisDevice, *pSwapchain, *pCreateInfo);
+        g_swapchains[*pSwapchain] = std::make_unique<vkShade::VulkanSwapchain>(
+            thisDevice, *pSwapchain, modifiedCreateInfo);
     }
 
     vkShade::Logger::debug("Swapchain created");
@@ -117,6 +118,19 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_QueuePresentKHR(VkQueue queue, const
 
         // Render layer
         swapchainData->render(imageIndex);
+    }
+
+    try
+    {
+        thisDevice.imageTracker->advance_frame();
+    }
+    catch (const std::exception& exception)
+    {
+        vkShade::Logger::warn("Buffer tracking failed: {}", exception.what());
+    }
+    catch (...)
+    {
+        vkShade::Logger::warn("Buffer tracking failed with an unknown error");
     }
 
     // Call down the chain to present

--- a/src/hooks/meson.build
+++ b/src/hooks/meson.build
@@ -2,6 +2,7 @@ hooks_source = [
   'hooks_device.cpp',
   'hooks_entrypoints.cpp',
   'hooks_instance.cpp',
+  'hooks_resources.cpp',
   'hooks_surface.cpp',
   'hooks_swapchain.cpp',
 ]

--- a/src/vk/gpu_timestamp.hpp
+++ b/src/vk/gpu_timestamp.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vkShade
+{
+    constexpr uint64_t timestamp_tick_delta(uint64_t begin, uint64_t end,
+                                            uint32_t validBits)
+    {
+        if (validBits == 0)
+            return 0;
+
+        if (validBits >= 64)
+            return end - begin;
+
+        const uint64_t mask = (uint64_t {1} << validBits) - 1;
+        return (end - begin) & mask;
+    }
+} // namespace vkShade

--- a/src/vk/gpu_timing.cpp
+++ b/src/vk/gpu_timing.cpp
@@ -57,6 +57,7 @@ void vkShade::GpuTiming::collect_results()
     m_state->effectsGpuMilliseconds.store(
         milliseconds(results[EffectsBegin].value, results[EffectsEnd].value),
         std::memory_order_relaxed);
+    m_state->gpuTimingSampleSequence.fetch_add(1, std::memory_order_release);
     m_state->gpuTimingValid.store(true, std::memory_order_release);
 }
 

--- a/src/vk/gpu_timing.cpp
+++ b/src/vk/gpu_timing.cpp
@@ -1,0 +1,138 @@
+#include "gpu_timing.hpp"
+
+#include <algorithm>
+#include <array>
+
+#include "core/logger.hpp"
+#include "hooks/hooks.hpp"
+
+vkShade::GpuTiming::GpuTiming(VulkanDevice& device,
+                              std::shared_ptr<DiagnosticsState> state)
+    : VulkanObject(device),
+      m_state(std::move(state))
+{}
+
+vkShade::GpuTiming::~GpuTiming()
+{
+    if (m_queryPool != VK_NULL_HANDLE)
+        m_device.dispatch.DestroyQueryPool(m_device.handle, m_queryPool, nullptr);
+}
+
+void vkShade::GpuTiming::collect_results()
+{
+    if (!m_pendingResults || m_queryPool == VK_NULL_HANDLE)
+        return;
+
+    struct QueryResult
+    {
+        uint64_t value;
+        uint64_t available;
+    };
+
+    std::array<QueryResult, QueryCount> results {};
+    const VkResult result = m_device.dispatch.GetQueryPoolResults(
+        m_device.handle, m_queryPool, 0, QueryCount, sizeof(results), results.data(),
+        sizeof(QueryResult), VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WITH_AVAILABILITY_BIT);
+
+    m_pendingResults = false;
+    if (result != VK_SUCCESS)
+    {
+        m_state->gpuTimingValid.store(false, std::memory_order_relaxed);
+        if (result != VK_NOT_READY)
+            Logger::warn("Unable to read GPU timing queries: {}", static_cast<int>(result));
+        return;
+    }
+
+    const bool allQueriesAvailable = std::ranges::all_of(
+        results, [](const QueryResult& query) { return query.available != 0; });
+    if (!allQueriesAvailable)
+    {
+        m_state->gpuTimingValid.store(false, std::memory_order_relaxed);
+        return;
+    }
+
+    m_state->totalGpuMilliseconds.store(
+        milliseconds(results[TotalBegin].value, results[TotalEnd].value),
+        std::memory_order_relaxed);
+    m_state->effectsGpuMilliseconds.store(
+        milliseconds(results[EffectsBegin].value, results[EffectsEnd].value),
+        std::memory_order_relaxed);
+    m_state->gpuTimingValid.store(true, std::memory_order_release);
+}
+
+bool vkShade::GpuTiming::begin_frame(VkCommandBuffer commandBuffer)
+{
+    m_recording = false;
+    if (!m_state->showPerformanceOverlay.load(std::memory_order_relaxed))
+    {
+        m_state->gpuTimingValid.store(false, std::memory_order_relaxed);
+        return false;
+    }
+
+    if (!ensure_query_pool())
+        return false;
+
+    m_device.dispatch.CmdResetQueryPool(commandBuffer, m_queryPool, 0, QueryCount);
+    m_device.dispatch.CmdWriteTimestamp(commandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                        m_queryPool, TotalBegin);
+    m_recording = true;
+    return true;
+}
+
+void vkShade::GpuTiming::begin_effects(VkCommandBuffer commandBuffer)
+{
+    if (m_recording)
+        m_device.dispatch.CmdWriteTimestamp(commandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                            m_queryPool, EffectsBegin);
+}
+
+void vkShade::GpuTiming::end_effects(VkCommandBuffer commandBuffer)
+{
+    if (m_recording)
+        m_device.dispatch.CmdWriteTimestamp(commandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                            m_queryPool, EffectsEnd);
+}
+
+void vkShade::GpuTiming::end_frame(VkCommandBuffer commandBuffer)
+{
+    if (!m_recording)
+        return;
+
+    m_device.dispatch.CmdWriteTimestamp(commandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                        m_queryPool, TotalEnd);
+    m_pendingResults = true;
+    m_recording = false;
+}
+
+bool vkShade::GpuTiming::ensure_query_pool()
+{
+    if (m_queryPool != VK_NULL_HANDLE)
+        return true;
+
+    if (m_creationAttempted || !m_state->gpuTimingSupported.load(std::memory_order_relaxed))
+        return false;
+
+    m_creationAttempted = true;
+    const VkQueryPoolCreateInfo createInfo {
+        .sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO,
+        .queryType = VK_QUERY_TYPE_TIMESTAMP,
+        .queryCount = QueryCount,
+    };
+
+    const VkResult result = m_device.dispatch.CreateQueryPool(
+        m_device.handle, &createInfo, nullptr, &m_queryPool);
+    if (result != VK_SUCCESS)
+    {
+        m_state->gpuTimingSupported.store(false, std::memory_order_relaxed);
+        Logger::warn("Unable to create GPU timing query pool: {}", static_cast<int>(result));
+        return false;
+    }
+
+    return true;
+}
+
+double vkShade::GpuTiming::milliseconds(uint64_t begin, uint64_t end) const
+{
+    const uint64_t ticks = timestamp_tick_delta(begin, end, m_device.timestampValidBits);
+    return static_cast<double>(ticks) * static_cast<double>(m_device.timestampPeriod) / 1'000'000.0;
+}

--- a/src/vk/gpu_timing.hpp
+++ b/src/vk/gpu_timing.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <memory>
+
+#include <vulkan/vulkan_core.h>
+
+#include "core/diagnostics_state.hpp"
+#include "gpu_timestamp.hpp"
+#include "object.hpp"
+
+namespace vkShade
+{
+    class GpuTiming : public VulkanObject
+    {
+    public:
+        GpuTiming(VulkanDevice& device, std::shared_ptr<DiagnosticsState> state);
+        ~GpuTiming() override;
+
+        void collect_results();
+        bool begin_frame(VkCommandBuffer commandBuffer);
+        void begin_effects(VkCommandBuffer commandBuffer);
+        void end_effects(VkCommandBuffer commandBuffer);
+        void end_frame(VkCommandBuffer commandBuffer);
+
+    private:
+        enum Query : uint32_t
+        {
+            TotalBegin,
+            EffectsBegin,
+            EffectsEnd,
+            TotalEnd,
+            QueryCount,
+        };
+
+        bool ensure_query_pool();
+        double milliseconds(uint64_t begin, uint64_t end) const;
+
+        std::shared_ptr<DiagnosticsState> m_state;
+        VkQueryPool m_queryPool {VK_NULL_HANDLE};
+        bool m_creationAttempted {false};
+        bool m_pendingResults {false};
+        bool m_recording {false};
+    };
+} // namespace vkShade

--- a/src/vk/image.cpp
+++ b/src/vk/image.cpp
@@ -110,6 +110,8 @@ vkShade::VulkanImage::VulkanImage(VulkanDevice& device, const reshadefx::texture
         if (!found)
             throw std::runtime_error("Unable to find texture: " + fileName);
     }
+
+    this->register_tracking(TrackedImageOrigin::VkShade);
 }
 
 void vkShade::VulkanImage::load_from_file(const std::string& filePath)
@@ -180,9 +182,12 @@ vkShade::VulkanImage::VulkanImage(VulkanDevice& device, VkExtent2D size, VkForma
 
     this->create_image();
     this->create_image_view();
+    this->register_tracking(TrackedImageOrigin::VkShade);
 }
 
-vkShade::VulkanImage::VulkanImage(VulkanDevice& device, VkImage image, VkExtent2D size, VkFormat format)
+vkShade::VulkanImage::VulkanImage(VulkanDevice& device, VkImage image, VkExtent2D size,
+                                  VkFormat format, VkImageUsageFlags usageFlags,
+                                  uint32_t arrayLayers)
     : VulkanObject(device)
 {
     Logger::trace("Wrapping existing image (Size: {}x{}, Format: {})",
@@ -194,15 +199,27 @@ vkShade::VulkanImage::VulkanImage(VulkanDevice& device, VkImage image, VkExtent2
     m_extent.height = size.height;
     m_extent.depth  = 1;
     m_format = format;
+    m_usageFlags = usageFlags;
     m_owning = false;  // IMPORTANT! We don't own the image here.
 
     // Only create the view (no image since we don't own it)
     this->create_image_view();
+    this->register_tracking(TrackedImageOrigin::Swapchain, arrayLayers);
 }
 
 vkShade::VulkanImage::~VulkanImage()
 {
     Logger::trace("Destroying VulkanImage");
+
+    try
+    {
+        m_device.imageTracker->unregister_view(m_imageView);
+        m_device.imageTracker->unregister_image(m_image);
+    }
+    catch (const std::exception& exception)
+    {
+        Logger::warn("Buffer tracking failed: {}", exception.what());
+    }
 
     if (m_imageView != VK_NULL_HANDLE)
         m_device.dispatch.DestroyImageView(m_device.handle, m_imageView, nullptr);
@@ -261,6 +278,63 @@ void vkShade::VulkanImage::create_image_view()
     };
 
 	VK_CHECK(m_device.dispatch.CreateImageView(m_device.handle, &viewInfo, nullptr, &m_imageView));
+}
+
+void vkShade::VulkanImage::register_tracking(TrackedImageOrigin origin,
+                                             uint32_t arrayLayers)
+{
+    const VkImageCreateInfo imageInfo = {
+        .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .imageType = VK_IMAGE_TYPE_2D,
+        .format = m_format,
+        .extent = {m_extent.width, m_extent.height, 1},
+        .mipLevels = 1,
+        .arrayLayers = arrayLayers,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .tiling = VK_IMAGE_TILING_OPTIMAL,
+        .usage = m_usageFlags,
+    };
+    const VkImageSubresourceRange viewRange = {
+        .aspectMask = m_format == VK_FORMAT_D32_SFLOAT
+                    ? VK_IMAGE_ASPECT_DEPTH_BIT
+                    : m_format == VK_FORMAT_S8_UINT
+                    ? VK_IMAGE_ASPECT_STENCIL_BIT
+                    : VK_IMAGE_ASPECT_COLOR_BIT,
+        .baseMipLevel = 0,
+        .levelCount = 1,
+        .baseArrayLayer = 0,
+        .layerCount = 1,
+    };
+
+    try
+    {
+        m_device.imageTracker->register_image(m_image, imageInfo, origin);
+        m_device.imageTracker->register_view(m_imageView, m_image, viewRange);
+    }
+    catch (const std::exception& exception)
+    {
+        try
+        {
+            m_device.imageTracker->unregister_view(m_imageView);
+            m_device.imageTracker->unregister_image(m_image);
+        }
+        catch (...)
+        {
+        }
+        Logger::warn("Buffer tracking failed: {}", exception.what());
+    }
+    catch (...)
+    {
+        try
+        {
+            m_device.imageTracker->unregister_view(m_imageView);
+            m_device.imageTracker->unregister_image(m_image);
+        }
+        catch (...)
+        {
+        }
+        Logger::warn("Buffer tracking failed with an unknown error");
+    }
 }
 
 void vkShade::VulkanImage::blit_from(VkCommandBuffer cmd, VkImage source)

--- a/src/vk/image.hpp
+++ b/src/vk/image.hpp
@@ -25,7 +25,8 @@ namespace vkShade
         VulkanImage(VulkanDevice& device, VkExtent2D size, VkFormat format, VkImageUsageFlags usageFlags);
 
         // Non-owning constructor: wraps existing image + creates its own view
-        VulkanImage(VulkanDevice& device, VkImage image, VkExtent2D size, VkFormat format);
+        VulkanImage(VulkanDevice& device, VkImage image, VkExtent2D size, VkFormat format,
+                    VkImageUsageFlags usageFlags, uint32_t arrayLayers);
 
         ~VulkanImage() override;
 
@@ -59,6 +60,7 @@ namespace vkShade
 
         void create_image();
         void create_image_view();
+        void register_tracking(TrackedImageOrigin origin, uint32_t arrayLayers = 1);
 
         void load_from_file(const std::string& filePath);
 

--- a/src/vk/image_tracker.cpp
+++ b/src/vk/image_tracker.cpp
@@ -1,0 +1,156 @@
+#include "image_tracker.hpp"
+
+#include <algorithm>
+
+namespace
+{
+    vkShade::ImageObservation operator|(vkShade::ImageObservation lhs,
+                                         vkShade::ImageObservation rhs)
+    {
+        return static_cast<vkShade::ImageObservation>(
+            static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
+    }
+}
+
+void vkShade::ImageTracker::register_image(VkImage image,
+                                           const VkImageCreateInfo& createInfo,
+                                           TrackedImageOrigin origin)
+{
+    if (image == VK_NULL_HANDLE)
+        return;
+
+    std::scoped_lock lock(m_mutex);
+    auto [it, inserted] = m_images.try_emplace(image);
+    if (!inserted)
+        return;
+
+    it->second.snapshot = {
+        .id = m_nextId++,
+        .origin = origin,
+        .type = createInfo.imageType,
+        .extent = createInfo.extent,
+        .format = createInfo.format,
+        .usage = createInfo.usage,
+        .observedAspects = 0,
+        .observations = ImageObservation::None,
+        .mipLevels = createInfo.mipLevels,
+        .arrayLayers = createInfo.arrayLayers,
+        .samples = createInfo.samples,
+        .lastSeenFrame = m_frame,
+        .useCount = 0,
+    };
+}
+
+void vkShade::ImageTracker::unregister_image(VkImage image)
+{
+    std::scoped_lock lock(m_mutex);
+    m_images.erase(image);
+
+    std::erase_if(m_views, [image](const auto& entry)
+    {
+        return entry.second.image == image;
+    });
+}
+
+void vkShade::ImageTracker::register_view(VkImageView view, VkImage image,
+                                          const VkImageSubresourceRange& range)
+{
+    if (view == VK_NULL_HANDLE || image == VK_NULL_HANDLE)
+        return;
+
+    std::scoped_lock lock(m_mutex);
+    m_views.insert_or_assign(view, ViewRecord {image, range});
+}
+
+void vkShade::ImageTracker::unregister_view(VkImageView view)
+{
+    std::scoped_lock lock(m_mutex);
+    m_views.erase(view);
+}
+
+void vkShade::ImageTracker::register_framebuffer(VkFramebuffer framebuffer,
+                                                 uint32_t attachmentCount,
+                                                 const VkImageView* attachments)
+{
+    if (framebuffer == VK_NULL_HANDLE)
+        return;
+
+    std::scoped_lock lock(m_mutex);
+    auto& views = m_framebuffers[framebuffer];
+    views.clear();
+    if (attachmentCount != 0 && attachments != nullptr)
+        views.assign(attachments, attachments + attachmentCount);
+}
+
+void vkShade::ImageTracker::unregister_framebuffer(VkFramebuffer framebuffer)
+{
+    std::scoped_lock lock(m_mutex);
+    m_framebuffers.erase(framebuffer);
+}
+
+void vkShade::ImageTracker::observe_view(VkImageView view,
+                                         ImageObservation observation)
+{
+    std::scoped_lock lock(m_mutex);
+    observe_view_locked(view, observation);
+}
+
+void vkShade::ImageTracker::observe_framebuffer(VkFramebuffer framebuffer)
+{
+    std::scoped_lock lock(m_mutex);
+    const auto framebufferIt = m_framebuffers.find(framebuffer);
+    if (framebufferIt == m_framebuffers.end())
+        return;
+
+    for (VkImageView view : framebufferIt->second)
+        observe_view_locked(view, ImageObservation::None);
+}
+
+void vkShade::ImageTracker::observe_view_locked(VkImageView view,
+                                                ImageObservation observation)
+{
+    const auto viewIt = m_views.find(view);
+    if (viewIt == m_views.end())
+        return;
+
+    const auto imageIt = m_images.find(viewIt->second.image);
+    if (imageIt == m_images.end())
+        return;
+
+    TrackedImageSnapshot& imageSnapshot = imageIt->second.snapshot;
+    imageSnapshot.observations = imageSnapshot.observations | observation;
+    imageSnapshot.observedAspects |= viewIt->second.range.aspectMask;
+    imageSnapshot.lastSeenFrame = m_frame;
+    ++imageSnapshot.useCount;
+}
+
+void vkShade::ImageTracker::advance_frame()
+{
+    std::scoped_lock lock(m_mutex);
+    ++m_frame;
+}
+
+std::vector<vkShade::TrackedImageSnapshot> vkShade::ImageTracker::snapshot() const
+{
+    std::scoped_lock lock(m_mutex);
+    std::vector<TrackedImageSnapshot> result;
+    result.reserve(m_images.size());
+
+    for (const auto& [image, record] : m_images)
+    {
+        const bool observed = record.snapshot.useCount != 0;
+        const bool ownedByLayer = record.snapshot.origin != TrackedImageOrigin::Application;
+        const bool storageCapable =
+            (record.snapshot.usage & VK_IMAGE_USAGE_STORAGE_BIT) != 0;
+        if (observed || ownedByLayer || storageCapable)
+            result.push_back(record.snapshot);
+    }
+
+    std::ranges::sort(result, [](const auto& lhs, const auto& rhs)
+    {
+        if (lhs.lastSeenFrame != rhs.lastSeenFrame)
+            return lhs.lastSeenFrame > rhs.lastSeenFrame;
+        return lhs.id < rhs.id;
+    });
+    return result;
+}

--- a/src/vk/image_tracker.hpp
+++ b/src/vk/image_tracker.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include <vulkan/vulkan_core.h>
+
+namespace vkShade
+{
+    enum class TrackedImageOrigin : uint8_t
+    {
+        Application,
+        Swapchain,
+        VkShade,
+    };
+
+    enum class ImageObservation : uint8_t
+    {
+        None = 0,
+        ColorAttachment = 1 << 0,
+        DepthStencilAttachment = 1 << 1,
+    };
+
+    struct TrackedImageSnapshot
+    {
+        uint64_t id;
+        TrackedImageOrigin origin;
+        VkImageType type;
+        VkExtent3D extent;
+        VkFormat format;
+        VkImageUsageFlags usage;
+        VkImageAspectFlags observedAspects;
+        ImageObservation observations;
+        uint32_t mipLevels;
+        uint32_t arrayLayers;
+        VkSampleCountFlagBits samples;
+        uint64_t lastSeenFrame;
+        uint64_t useCount;
+    };
+
+    class ImageTracker
+    {
+    public:
+        void register_image(VkImage image, const VkImageCreateInfo& createInfo,
+                            TrackedImageOrigin origin);
+        void unregister_image(VkImage image);
+
+        void register_view(VkImageView view, VkImage image,
+                           const VkImageSubresourceRange& range);
+        void unregister_view(VkImageView view);
+
+        void register_framebuffer(VkFramebuffer framebuffer,
+                                  uint32_t attachmentCount,
+                                  const VkImageView* attachments);
+        void unregister_framebuffer(VkFramebuffer framebuffer);
+
+        void observe_view(VkImageView view, ImageObservation observation);
+        void observe_framebuffer(VkFramebuffer framebuffer);
+        void advance_frame();
+
+        std::vector<TrackedImageSnapshot> snapshot() const;
+
+    private:
+        struct ImageRecord
+        {
+            TrackedImageSnapshot snapshot;
+        };
+
+        struct ViewRecord
+        {
+            VkImage image;
+            VkImageSubresourceRange range;
+        };
+
+        void observe_view_locked(VkImageView view, ImageObservation observation);
+
+        mutable std::mutex m_mutex;
+        std::unordered_map<VkImage, ImageRecord> m_images;
+        std::unordered_map<VkImageView, ViewRecord> m_views;
+        std::unordered_map<VkFramebuffer, std::vector<VkImageView>> m_framebuffers;
+        uint64_t m_nextId = 1;
+        uint64_t m_frame = 0;
+    };
+} // namespace vkShade

--- a/src/vk/meson.build
+++ b/src/vk/meson.build
@@ -1,5 +1,6 @@
 libvk_source = [
   'buffer.cpp',
+  'gpu_timing.cpp',
   'image.cpp',
   'image_tracker.cpp',
   'initializers.cpp',

--- a/src/vk/meson.build
+++ b/src/vk/meson.build
@@ -1,6 +1,7 @@
 libvk_source = [
   'buffer.cpp',
   'image.cpp',
+  'image_tracker.cpp',
   'initializers.cpp',
   'reshade_effect.cpp',
   'reshade_uniforms.cpp',

--- a/src/vk/swapchain.cpp
+++ b/src/vk/swapchain.cpp
@@ -17,7 +17,8 @@
 #include "reshade_uniforms.hpp"
 
 vkShade::VulkanSwapchain::VulkanSwapchain(VulkanDevice& device, VkSwapchainKHR swapchain, VkSwapchainCreateInfoKHR swapchainInfo)
-    : VulkanObject(device)
+    : VulkanObject(device),
+      m_gpuTiming(device, device.diagnosticsState)
 {
     // Store the swapchain info
     m_swapchain = swapchain;
@@ -176,6 +177,7 @@ void vkShade::VulkanSwapchain::render(uint32_t imageIndex)
 
     // Wait until the previous command buffer has finished executing. Timeout of 1 second.
 	VK_CHECK(m_device.dispatch.WaitForFences(m_device.handle, 1, &m_fence, true, 1000000000));
+	m_gpuTiming.collect_results();
 	VK_CHECK(m_device.dispatch.ResetFences(m_device.handle, 1, &m_fence));
 
     // Reset the command buffer
@@ -187,6 +189,7 @@ void vkShade::VulkanSwapchain::render(uint32_t imageIndex)
         .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
     };
     m_device.dispatch.BeginCommandBuffer(m_commandBuffer, &beginInfo);
+    m_gpuTiming.begin_frame(m_commandBuffer);
 
     // Blit swapchain image to ping-pong and transition to COLOR_ATTACHMENT
     swapchainImage->transition_layout(m_commandBuffer, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
@@ -211,6 +214,8 @@ void vkShade::VulkanSwapchain::render(uint32_t imageIndex)
     VulkanImage* readImage = m_pingPongA.get();
     VulkanImage* writeImage = m_pingPongB.get();
 
+    m_gpuTiming.begin_effects(m_commandBuffer);
+
     if (enabled)
     {
         for (auto effect : m_effects)
@@ -234,6 +239,8 @@ void vkShade::VulkanSwapchain::render(uint32_t imageIndex)
             std::swap(readImage, writeImage);
         }
     }
+
+    m_gpuTiming.end_effects(m_commandBuffer);
 
     VulkanImage* finalImage = readImage;
 
@@ -269,6 +276,8 @@ void vkShade::VulkanSwapchain::render(uint32_t imageIndex)
     swapchainImage->transition_layout(m_commandBuffer, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
     readImage->blit_to(m_commandBuffer, swapchainImage->image());
     swapchainImage->transition_layout(m_commandBuffer, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+
+    m_gpuTiming.end_frame(m_commandBuffer);
 
     // End and submit
     m_device.dispatch.EndCommandBuffer(m_commandBuffer);

--- a/src/vk/swapchain.cpp
+++ b/src/vk/swapchain.cpp
@@ -33,7 +33,9 @@ vkShade::VulkanSwapchain::VulkanSwapchain(VulkanDevice& device, VkSwapchainKHR s
     // Create image views
     for (auto& image : images)
     {
-        m_images.push_back(std::make_unique<VulkanImage>(device, image, m_extent, m_format));
+        m_images.push_back(std::make_unique<VulkanImage>(
+            device, image, m_extent, m_format, swapchainInfo.imageUsage,
+            swapchainInfo.imageArrayLayers));
     }
 
 	VkImageUsageFlags drawImageUsages {};
@@ -244,6 +246,15 @@ void vkShade::VulkanSwapchain::render(uint32_t imageIndex)
     };
 
     VkRenderingInfo renderingInfo = vkinit::rendering_info(m_extent, colorAttachments, nullptr);
+    try
+    {
+        m_device.imageTracker->observe_view(
+            finalImage->image_view(), ImageObservation::ColorAttachment);
+    }
+    catch (const std::exception& exception)
+    {
+        Logger::warn("Buffer tracking failed: {}", exception.what());
+    }
     m_device.dispatch.CmdBeginRendering(m_commandBuffer, &renderingInfo);
 
     // Render ImGui on top of everything

--- a/src/vk/swapchain.hpp
+++ b/src/vk/swapchain.hpp
@@ -7,6 +7,7 @@
 
 #include "core/events/reload_effects.hpp"
 #include "object.hpp"
+#include "gpu_timing.hpp"
 #include "reshade_effect.hpp"
 
 namespace vkShade
@@ -45,6 +46,7 @@ namespace vkShade
         VkFence m_fence {VK_NULL_HANDLE};
         VkCommandPool m_commandPool {VK_NULL_HANDLE};
         VkCommandBuffer m_commandBuffer {VK_NULL_HANDLE};
+        GpuTiming m_gpuTiming;
         std::vector<std::shared_ptr<ReshadeEffect>> m_effects;
         std::shared_ptr<VulkanImage> m_pingPongA;
         std::shared_ptr<VulkanImage> m_pingPongB;

--- a/tests/gpu_timing_tests.cpp
+++ b/tests/gpu_timing_tests.cpp
@@ -1,0 +1,13 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "vk/gpu_timestamp.hpp"
+
+TEST_CASE("timestamp deltas preserve full-width counters")
+{
+    CHECK(vkShade::timestamp_tick_delta(100, 175, 64) == 75);
+}
+
+TEST_CASE("timestamp deltas handle valid-bit wraparound")
+{
+    CHECK(vkShade::timestamp_tick_delta(250, 5, 8) == 11);
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -47,8 +47,17 @@ reshade_uniform_tests = executable('reshade_uniform_tests',
   include_directories : include_directories('../src')
 )
 
+gpu_timing_tests = executable('gpu_timing_tests',
+  'gpu_timing_tests.cpp',
+  dependencies : [
+    catch2,
+  ],
+  include_directories : include_directories('../src')
+)
+
 test('ConfigObserver', config_observer_tests)
 test('ConfigParser', config_parser_tests)
 test('ConfigStore', config_store_tests)
 test('EventBus', event_bus_tests)
 test('ReshadeUniforms', reshade_uniform_tests)
+test('GpuTiming', gpu_timing_tests)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -55,9 +55,18 @@ gpu_timing_tests = executable('gpu_timing_tests',
   include_directories : include_directories('../src')
 )
 
+rolling_statistics_tests = executable('rolling_statistics_tests',
+  'rolling_statistics_tests.cpp',
+  dependencies : [
+    catch2,
+  ],
+  include_directories : include_directories('../src')
+)
+
 test('ConfigObserver', config_observer_tests)
 test('ConfigParser', config_parser_tests)
 test('ConfigStore', config_store_tests)
 test('EventBus', event_bus_tests)
 test('ReshadeUniforms', reshade_uniform_tests)
 test('GpuTiming', gpu_timing_tests)
+test('RollingStatistics', rolling_statistics_tests)

--- a/tests/rolling_statistics_tests.cpp
+++ b/tests/rolling_statistics_tests.cpp
@@ -1,0 +1,48 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "core/rolling_statistics.hpp"
+
+TEST_CASE("rolling statistics report samples in their active window")
+{
+    vkShade::RollingStatistics<3> statistics;
+
+    CHECK_FALSE(statistics.snapshot().has_value());
+
+    statistics.add(1.0);
+    statistics.add(2.0);
+    statistics.add(3.0);
+
+    const auto snapshot = statistics.snapshot();
+    REQUIRE(snapshot.has_value());
+    CHECK(snapshot->current == Catch::Approx(3.0));
+    CHECK(snapshot->average == Catch::Approx(2.0));
+    CHECK(snapshot->minimum == Catch::Approx(1.0));
+    CHECK(snapshot->maximum == Catch::Approx(3.0));
+}
+
+TEST_CASE("rolling statistics replace the oldest sample")
+{
+    vkShade::RollingStatistics<3> statistics;
+    statistics.add(1.0);
+    statistics.add(2.0);
+    statistics.add(3.0);
+    statistics.add(4.0);
+
+    const auto snapshot = statistics.snapshot();
+    REQUIRE(snapshot.has_value());
+    CHECK(snapshot->current == Catch::Approx(4.0));
+    CHECK(snapshot->average == Catch::Approx(3.0));
+    CHECK(snapshot->minimum == Catch::Approx(2.0));
+    CHECK(snapshot->maximum == Catch::Approx(4.0));
+}
+
+TEST_CASE("rolling statistics reset their accumulated state")
+{
+    vkShade::RollingStatistics<3> statistics;
+    statistics.add(1.0);
+
+    statistics.reset();
+
+    CHECK_FALSE(statistics.snapshot().has_value());
+}


### PR DESCRIPTION
## Summary

Add developer-oriented Vulkan resource and performance diagnostics to the vkShade overlay.

This remains a draft proof of concept. The image tracker provides a concrete reference for useful metadata and GUI workflows while upstream resource and depth-buffer architecture continues to evolve.

The branch is kept current so its functionality can be evaluated against new upstream work and individual parts can be retained independently.

## Buffers panel

Add device-scoped tracking of application, swapchain, and vkShade-owned images, including their use as framebuffer and dynamic-rendering attachments.

The Buffers tab presents factual metadata such as origin, observed role, extent, format, sample count, mip levels, array layers, usage flags, aspects, and observation history.

Category controls provide soft prioritization for color, depth/stencil, storage, swapchain, and vkShade-internal images. Matching rows move ahead of the existing stable order while all other resources remain visible with subdued styling.

Snapshots are refreshed only while the panel is visible, and the table uses `ImGuiListClipper` for large image sets. Tracking remains observational: diagnostic failures are logged without changing Vulkan calls, return values, or application-visible behavior.

## GPU timing

Measure GPU time using Vulkan timestamp queries around:

- the complete vkShade render path;
- the effect chain;
- the remaining copy and GUI work.

The query pool is created lazily, and timing is active only while performance diagnostics are requested. Results are collected after the existing per-swapchain fence wait, avoiding an additional synchronization point.

Timestamp counters with fewer than 64 valid bits and counter wraparound are handled explicitly.

## Performance HUD

Add a non-interactive diagnostics HUD that remains visible while the main window is closed.

For total vkShade work, effects, and remaining work, it displays:

- current GPU time;
- rolling average;
- rolling minimum;
- rolling maximum.

Statistics cover the latest 120 published samples. A sequence counter ensures that each result is ingested once, and the rolling windows reset when timing becomes unavailable.

The HUD also offers an independent read-only effects-status display backed by the same internal state as the GUI checkbox and input hotkey. Fixed-width values use the UI monospace font so changing measurements do not resize or jitter the right-anchored overlay.

## Validation

- Release build succeeds.
- `git diff --check` is clean.
- All eight unit tests pass.
- Timestamp delta and valid-bit wraparound behavior are covered.
- Rolling-window fill, replacement, and reset behavior are covered.
- Buffer diagnostics were smoke-tested with Euro Truck Simulator 2 under Proton.
- The GPU timing path reported approximately 2.1 ms for an active six-effect ETS2 shader stack at 4K output.

The PR deliberately remains in draft while the resource and depth-buffer architecture is developed upstream.