### PR TITLE
fix(input): forward vertical mouse wheel to GUI

### DIFF
--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -131,6 +131,9 @@ void vkShade::GuiManager::update(float deltaTime, VkExtent2D swapchainExtent)
     io.AddMouseButtonEvent(0, input.is_mouse_button_pressed(MouseButton::LEFT));
     io.AddMouseButtonEvent(1, input.is_mouse_button_pressed(MouseButton::RIGHT));
     io.AddMouseButtonEvent(2, input.is_mouse_button_pressed(MouseButton::MIDDLE));
+    float mouseWheelDelta = input.consume_mouse_wheel_delta();
+    if (mouseWheelDelta != 0.0f)
+        io.AddMouseWheelEvent(0.0f, mouseWheelDelta);
 
     io.DisplaySize = ImVec2((float)swapchainExtent.width, (float)swapchainExtent.height);
     io.DeltaTime = deltaTime;

--- a/src/input/input_backend_wayland.cpp
+++ b/src/input/input_backend_wayland.cpp
@@ -96,7 +96,10 @@ void vkShade::InputBackendWayland::on_pointer_button(uint32_t serial, uint32_t t
 
 void vkShade::InputBackendWayland::on_pointer_axis(uint32_t time, uint32_t axis, wl_fixed_t value)
 {
-    // Handle scroll wheel
+    // TODO(wayland): Forward the vertical axis through
+    // handle_mouse_wheel_event() once this can be validated with a native
+    // Wayland Vulkan client. Confirm direction and discrete/value120 scaling
+    // instead of assuming X11 button-wheel semantics.
     float scroll = wl_fixed_to_double(value);
     Logger::trace("Scroll axis {} value {}", axis, scroll);
 }

--- a/src/input/input_backend_xcb.cpp
+++ b/src/input/input_backend_xcb.cpp
@@ -114,14 +114,17 @@ void vkShade::InputBackendXcb::handle_key_event(uint32_t keyCode, bool pressed)
 void vkShade::InputBackendXcb::on_mouse_button(uint8_t button, bool pressed)
 {
     // XCB button codes: 1=left, 2=middle, 3=right, 4=scroll up, 5=scroll down
+    if (pressed && (button == 4 || button == 5))
+    {
+        handle_mouse_wheel_event(button == 4 ? 1.0f : -1.0f);
+        return;
+    }
+
     MouseButton mouseButton;
     switch (button) {
         case 1: mouseButton = MouseButton::LEFT; break;
         case 2: mouseButton = MouseButton::MIDDLE; break;
         case 3: mouseButton = MouseButton::RIGHT; break;
-        case 4:  // Scroll up
-        case 5:  // Scroll down
-            return;  // Ignore scroll for now
         default: return;
     }
 

--- a/src/input/input_backend_xlib.cpp
+++ b/src/input/input_backend_xlib.cpp
@@ -20,6 +20,24 @@ vkShade::InputBackendXlib::InputBackendXlib(Display* display, Window window)
 
     // Initialize previous key states
     std::memset(m_previousKeymap, 0, sizeof(m_previousKeymap));
+
+    // Observe wheel button events without consuming the application's queue.
+    m_wheelDisplay = XOpenDisplay(DisplayString(m_display));
+    if (m_wheelDisplay)
+    {
+        XSelectInput(m_wheelDisplay, m_window, ButtonPressMask | ButtonReleaseMask);
+        XFlush(m_wheelDisplay);
+    }
+    else
+    {
+        Logger::warn("[Xlib] Could not open a display connection for mouse wheel input");
+    }
+}
+
+vkShade::InputBackendXlib::~InputBackendXlib()
+{
+    if (m_wheelDisplay)
+        XCloseDisplay(m_wheelDisplay);
 }
 
 void vkShade::InputBackendXlib::process_events()
@@ -49,6 +67,20 @@ void vkShade::InputBackendXlib::process_events()
     // Update previous state
     std::memcpy(m_previousKeymap, keymap, sizeof(keymap));
 
+    if (m_wheelDisplay)
+    {
+        while (XPending(m_wheelDisplay))
+        {
+            XEvent event {};
+            XNextEvent(m_wheelDisplay, &event);
+            if (event.type == ButtonPress
+                && (event.xbutton.button == Button4 || event.xbutton.button == Button5))
+            {
+                handle_mouse_wheel_event(event.xbutton.button == Button4 ? 1.0f : -1.0f);
+            }
+        }
+    }
+
     // Query mouse state
     query_mouse_state();
 }
@@ -74,7 +106,6 @@ void vkShade::InputBackendXlib::handle_key_event(uint32_t keyCode, bool pressed)
     // Call base class to update key state map
     this->handle_keyboard_event(keysym, pressed);
 }
-
 
 void vkShade::InputBackendXlib::query_mouse_state()
 {

--- a/src/input/input_backend_xlib.hpp
+++ b/src/input/input_backend_xlib.hpp
@@ -11,11 +11,13 @@ namespace vkShade
     {
     public:
         InputBackendXlib(Display* display, Window window);
+        ~InputBackendXlib() override;
 
         void process_events() override;
 
     private:
         Display* m_display;
+        Display* m_wheelDisplay {nullptr};
         Window   m_window;
         char     m_previousKeymap[32];  // Track previous keyboard state
 

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -113,6 +113,18 @@ void vkShade::InputManager::handle_mouse_motion_event(float x, float y)
     m_mouseDelta = m_currentMousePosition - m_previousMousePosition;
 }
 
+void vkShade::InputManager::handle_mouse_wheel_event(float delta)
+{
+    m_mouseWheelDelta += delta;
+}
+
+float vkShade::InputManager::consume_mouse_wheel_delta()
+{
+    float delta = m_mouseWheelDelta;
+    m_mouseWheelDelta = 0.0f;
+    return delta;
+}
+
 bool vkShade::InputManager::is_action_pressed(const std::string& actionName) const
 {
     auto it = m_actionBindings.find(actionName);

--- a/src/input/input_manager.hpp
+++ b/src/input/input_manager.hpp
@@ -36,6 +36,7 @@ namespace vkShade
 
         glm::vec2 mouse_position() const { return m_currentMousePosition; }
         glm::vec2 mouse_delta() const { return m_mouseDelta; }
+        float consume_mouse_wheel_delta();
 
         virtual void process_events() = 0;
 
@@ -51,6 +52,7 @@ namespace vkShade
         void handle_keyboard_event(const xkb_keysym_t& keysym, bool pressed);
         void handle_mouse_button_event(MouseButton button, bool pressed);
         void handle_mouse_motion_event(float x, float y);
+        void handle_mouse_wheel_event(float delta);
 
         void on_keybind_changed(const std::string& configKey, std::string enumString);
 
@@ -71,6 +73,7 @@ namespace vkShade
         glm::vec2 m_currentMousePosition {0.0f, 0.0f};
         glm::vec2 m_previousMousePosition {0.0f, 0.0f};
         glm::vec2 m_mouseDelta {0.0f, 0.0f};
+        float m_mouseWheelDelta = 0.0f;
 
         std::unordered_map<MouseButton, bool> m_currentMouseStates;
         std::unordered_map<MouseButton, bool> m_previousMouseStates;


### PR DESCRIPTION
## Summary

Forward vertical mouse-wheel input from the XCB and Xlib backends to ImGui.

- translate X11 button 4/5 presses into vertical wheel deltas
- accumulate wheel input in `InputManager`
- consume the accumulated delta once per GUI frame
- observe Xlib wheel events through a separate display connection without consuming events from the application's queue
- leave native Wayland axis normalization for a separately testable follow-up

Horizontal scrolling is intentionally outside the scope of this change.

## Testing

- release build with `meson compile -C build`
- exercised through the vkShade GUI under ETS2 via Proton/XWayland