### PR TITLE
feat(gui): add effects enable control

### DIFF
--- a/src/core/effects_state.hpp
+++ b/src/core/effects_state.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <atomic>
+
+namespace vkShade
+{
+    struct EffectsState
+    {
+        std::atomic_bool enabled {true};
+    };
+} // namespace vkShade

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -14,6 +14,7 @@
 #include "input_helpers.hpp"
 
 vkShade::GuiManager::GuiManager(VulkanDevice deviceContext, VkFormat swapchainFormat)
+    : m_mainWindow(deviceContext.effectsState)
 {
     m_device = deviceContext.handle;
 

--- a/src/gui/panels/effects_panel.cpp
+++ b/src/gui/panels/effects_panel.cpp
@@ -6,10 +6,11 @@
 #include "../gui_helpers.hpp"
 #include "../gui_style.hpp"
 
-vkShade::EffectsPanel::EffectsPanel()
+vkShade::EffectsPanel::EffectsPanel(std::shared_ptr<EffectsState> effectsState)
     : m_config(vkShade::Locator<ConfigManager>::get().app()),
       m_preset(vkShade::Locator<ConfigManager>::get().preset()),
-      m_eventBus(vkShade::Locator<EventBus>::get())
+      m_eventBus(vkShade::Locator<EventBus>::get()),
+      m_effectsState(std::move(effectsState))
 {}
 
 void vkShade::EffectsPanel::render()
@@ -29,9 +30,14 @@ void vkShade::EffectsPanel::render()
 
 void vkShade::EffectsPanel::render_controls_bar()
 {
+    bool effectsEnabled = m_effectsState->enabled.load(std::memory_order_relaxed);
+    if (ImGui::Checkbox("Effects enabled", &effectsEnabled))
+        m_effectsState->enabled.store(effectsEnabled, std::memory_order_relaxed);
+
     const char* label = "Reload Active Effects";
     float buttonWidth = ImGui::CalcTextSize(label).x + ImGui::GetStyle().FramePadding.x * 2.0f;
 
+    ImGui::SameLine();
     ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x - buttonWidth);
 
     if (ImGui::Button(label))

--- a/src/gui/panels/effects_panel.hpp
+++ b/src/gui/panels/effects_panel.hpp
@@ -1,11 +1,13 @@
 #pragma once
 #include "panel.hpp"
 
+#include <memory>
 #include <unordered_set>
 
 #include <imgui.h>
 
 #include "config/config_store.hpp"
+#include "core/effects_state.hpp"
 #include "core/event_bus.hpp"
 
 namespace vkShade
@@ -14,7 +16,7 @@ namespace vkShade
     class EffectsPanel : public GuiPanel
     {
     public:
-        EffectsPanel();
+        explicit EffectsPanel(std::shared_ptr<EffectsState> effectsState);
 
         void render() override;
 
@@ -22,6 +24,7 @@ namespace vkShade
         ConfigStore& m_config;
         ConfigStore& m_preset;
         EventBus&    m_eventBus;
+        std::shared_ptr<EffectsState> m_effectsState;
 
         // UI-only state (widget selections, window position)
         int32_t m_selectedAvailable = -1;

--- a/src/gui/windows/main_window.cpp
+++ b/src/gui/windows/main_window.cpp
@@ -3,8 +3,9 @@
 #include "config/config_manager.hpp"
 #include "core/service_locator.hpp"
 
-vkShade::MainWindow::MainWindow()
-    : m_preset(vkShade::Locator<ConfigManager>::get().preset())
+vkShade::MainWindow::MainWindow(std::shared_ptr<EffectsState> effectsState)
+    : m_preset(vkShade::Locator<ConfigManager>::get().preset()),
+      m_effectsPanel(std::move(effectsState))
 {}
 
 void vkShade::MainWindow::render()

--- a/src/gui/windows/main_window.hpp
+++ b/src/gui/windows/main_window.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <memory>
+
 #include <imgui.h>
 
 #include "config/config_store.hpp"
+#include "core/effects_state.hpp"
 #include "../panels/effects_panel.hpp"
 #include "../panels/log_panel.hpp"
 #include "../window.hpp"
@@ -14,7 +17,7 @@ namespace vkShade
     class MainWindow : public GuiWindow
     {
     public:
-        MainWindow();
+        explicit MainWindow(std::shared_ptr<EffectsState> effectsState);
 
         void render() override;
 

--- a/src/hooks/hooks.hpp
+++ b/src/hooks/hooks.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
 #include <assert.h>
+#include <memory>
 #include <shared_mutex>
 #include <unordered_map>
 
 #include <vk_mem_alloc.h>
 #include <vulkan/utility/vk_dispatch_table.h>
 #include <vulkan/vulkan_core.h>
+
+#include "core/effects_state.hpp"
 
 #undef VK_LAYER_EXPORT
 #if defined(__GNUC__) && __GNUC__ >= 4
@@ -34,6 +37,7 @@ struct VulkanDevice
     VkQueue       queue;
     uint32_t      queueFamilyIndex;
     VkCommandPool commandPool;
+    std::shared_ptr<vkShade::EffectsState> effectsState;
 };
 
 inline void* const dispatch_key_from_handle(const void* handle)

--- a/src/hooks/hooks_device.cpp
+++ b/src/hooks/hooks_device.cpp
@@ -102,6 +102,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
     thisDevice.handle = *pDevice;
     thisDevice.physicalDevice = physicalDevice;
     thisDevice.instance = thisInstance.handle;
+    thisDevice.effectsState = std::make_shared<vkShade::EffectsState>();
 
     // Initialize dispatch table
     vkuInitDeviceDispatchTable(*pDevice, &thisDevice.dispatch, gdpa);

--- a/src/vk/swapchain.cpp
+++ b/src/vk/swapchain.cpp
@@ -201,14 +201,16 @@ void vkShade::VulkanSwapchain::render(uint32_t imageIndex)
 
     // Render effects if enabled
     auto& input = vkShade::Locator<vkShade::InputManager>::get();
-    static bool enabled = true;
     if (input.is_action_just_pressed("ToggleEffects"))
-        enabled = !enabled;
+    {
+        const bool enabled = m_device.effectsState->enabled.load(std::memory_order_relaxed);
+        m_device.effectsState->enabled.store(!enabled, std::memory_order_relaxed);
+    }
 
     VulkanImage* readImage = m_pingPongA.get();
     VulkanImage* writeImage = m_pingPongB.get();
 
-    if (enabled)
+    if (m_device.effectsState->enabled.load(std::memory_order_relaxed))
     {
         for (auto effect : m_effects)
         {


### PR DESCRIPTION
## Summary

Expose the current effects state in the Effects tab and allow it to be changed directly from the GUI.

- add an `Effects enabled` checkbox next to `Reload Active Effects`
- keep the checkbox synchronized with the existing `ToggleEffects` hotkey
- replace the function-local toggle state with shared, device-scoped state
- make swapchain rendering and the GUI use the same state

## Motivation

The hotkey is useful for visual A/B comparisons, but after switching several times it can be difficult to remember whether the effect chain is currently enabled.

The checkbox makes the active state immediately visible while preserving the existing hotkey workflow.

## Implementation

The current implementation stores the state in a device-scoped shared atomic value. This lets the rendering path, hotkey, and GUI observe and modify the same state without introducing a separate UI-only copy.

You previously mentioned that you may prefer different ownership for this state. I have kept the current implementation as a concrete review basis and am happy to adapt it to your preferred design.

## Scope

This branch is now based directly on the current `main` and contains a single commit:

- `1529171 feat(gui): add effects enable control`

It no longer depends on the superseded live-log PR or any other local feature branch.

## Testing

- release build with `meson compile -C build`
- all six configured tests pass with `meson test -C build --print-errorlogs`
- `git diff --check`
- range-diff against the previous standalone effects-control commit
- previously smoke-tested in ETS2 as part of the local integration queue

A final ETS2 smoke test of checkbox/hotkey synchronization will be done before removing the draft status.