### PR TITLE
feat(gui): add live log panel

### DIFF
--- a/src/core/logger.hpp
+++ b/src/core/logger.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdlib>
 #include <memory>
 #include <string>
@@ -9,6 +10,7 @@
 
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/ringbuffer_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace vkShade
@@ -19,6 +21,8 @@ namespace vkShade
     class Logger
     {
     public:
+        static constexpr std::size_t recent_message_capacity = 2000;
+
         static void trace(std::string_view msg)
         {
             get().trace(msg);
@@ -85,14 +89,30 @@ namespace vkShade
             get().critical(fmt, std::forward<Args>(args)...);
         }
 
+        static std::vector<std::string> recent_messages(std::size_t limit = 0)
+        {
+            return state().history->last_formatted(limit);
+        }
+
     private:
-        static spdlog::logger& get()
+        struct State
+        {
+            std::shared_ptr<spdlog::sinks::ringbuffer_sink_mt> history;
+            std::shared_ptr<spdlog::logger> logger;
+        };
+
+        static State& state()
         {
             // Keep the logger independent from spdlog's process-wide registry.
-            static auto logger = []
+            static State instance = []
             {
+                State result;
                 std::vector<spdlog::sink_ptr> sinks;
                 sinks.push_back(std::make_shared<spdlog::sinks::stderr_color_sink_mt>());
+
+                result.history = std::make_shared<spdlog::sinks::ringbuffer_sink_mt>(
+                    recent_message_capacity);
+                sinks.push_back(result.history);
 
                 if (const char* path = std::getenv("VKSHADE_LOG_FILE"))
                     // Function-local static initialization opens and truncates the log
@@ -100,34 +120,39 @@ namespace vkShade
                     sinks.push_back(
                         std::make_shared<spdlog::sinks::basic_file_sink_mt>(path, true));
 
-                auto result = std::make_shared<spdlog::logger>(
+                result.logger = std::make_shared<spdlog::logger>(
                     "vkShade", sinks.begin(), sinks.end());
-                result->flush_on(spdlog::level::trace);
+                result.logger->flush_on(spdlog::level::trace);
 
                 const char* configuredLevel = std::getenv("VKSHADE_LOG_LEVEL");
                 const std::string level = configuredLevel ? configuredLevel : "info";
                 if (level == "trace")
-                    result->set_level(spdlog::level::trace);
+                    result.logger->set_level(spdlog::level::trace);
                 else if (level == "debug")
-                    result->set_level(spdlog::level::debug);
+                    result.logger->set_level(spdlog::level::debug);
                 else if (level == "info")
-                    result->set_level(spdlog::level::info);
+                    result.logger->set_level(spdlog::level::info);
                 else if (level == "warn" || level == "warning")
-                    result->set_level(spdlog::level::warn);
+                    result.logger->set_level(spdlog::level::warn);
                 else if (level == "error")
-                    result->set_level(spdlog::level::err);
+                    result.logger->set_level(spdlog::level::err);
                 else if (level == "critical")
-                    result->set_level(spdlog::level::critical);
+                    result.logger->set_level(spdlog::level::critical);
                 else if (level == "off")
-                    result->set_level(spdlog::level::off);
+                    result.logger->set_level(spdlog::level::off);
                 else
-                    result->set_level(spdlog::level::info);
+                    result.logger->set_level(spdlog::level::info);
 
-                result->debug("vkShade logger initialized");
+                result.logger->debug("vkShade logger initialized");
                 return result;
             }();
 
-            return *logger;
+            return instance;
+        }
+
+        static spdlog::logger& get()
+        {
+            return *state().logger;
         }
     };
 }

--- a/src/gui/meson.build
+++ b/src/gui/meson.build
@@ -1,5 +1,6 @@
 libgui_source = [
   'panels/effects_panel.cpp',
+  'panels/log_panel.cpp',
   'windows/about_window.cpp',
   'windows/main_window.cpp',
   'gui_manager.cpp',

--- a/src/gui/panels/log_panel.cpp
+++ b/src/gui/panels/log_panel.cpp
@@ -1,0 +1,50 @@
+#include "log_panel.hpp"
+
+#include <imgui.h>
+
+#include "core/logger.hpp"
+
+void vkShade::LogPanel::render()
+{
+    if (!m_paused &&
+        (m_messages.empty() || ImGui::GetTime() >= m_nextRefresh))
+    {
+        m_messages = Logger::recent_messages(Logger::recent_message_capacity);
+        m_nextRefresh = ImGui::GetTime() + 0.25;
+    }
+
+    ImGui::Checkbox("Pause", &m_paused);
+    ImGui::SameLine();
+    ImGui::Checkbox("Follow", &m_follow);
+    ImGui::SameLine();
+    ImGui::TextDisabled("%zu / %zu messages", m_messages.size(),
+                        Logger::recent_message_capacity);
+
+    ImGui::Separator();
+
+    if (ImGui::BeginChild("LogMessages", ImVec2(0, 0), false,
+                          ImGuiWindowFlags_HorizontalScrollbar))
+    {
+        ImGuiListClipper clipper;
+        clipper.Begin(static_cast<int>(m_messages.size()));
+        while (clipper.Step())
+        {
+            for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; ++i)
+            {
+                const std::string& message = m_messages[i];
+                const char* begin = message.data();
+                const char* end = begin + message.size();
+                while (end != begin && (end[-1] == '\n' || end[-1] == '\r'))
+                    --end;
+                ImGui::TextUnformatted(begin, end);
+            }
+        }
+
+        if (m_follow)
+        {
+            ImGui::Dummy(ImVec2(0, 0));
+            ImGui::SetScrollHereY(1.0f);
+        }
+    }
+    ImGui::EndChild();
+}

--- a/src/gui/panels/log_panel.cpp
+++ b/src/gui/panels/log_panel.cpp
@@ -1,8 +1,65 @@
 #include "log_panel.hpp"
 
+#include <string_view>
+
 #include <imgui.h>
 
 #include "core/logger.hpp"
+#include "gui/gui_style.hpp"
+
+namespace
+{
+    enum class LogMessageLevel
+    {
+        Unknown,
+        Trace,
+        Debug,
+        Info,
+        Warning,
+        Error,
+        Critical,
+    };
+
+    ImVec4 blend_color(const ImVec4& from, const ImVec4& to, float amount)
+    {
+        return ImVec4(
+            from.x + (to.x - from.x) * amount,
+            from.y + (to.y - from.y) * amount,
+            from.z + (to.z - from.z) * amount,
+            from.w + (to.w - from.w) * amount);
+    }
+
+    LogMessageLevel log_message_level(std::string_view message)
+    {
+        const size_t loggerSeparator = message.find("] [");
+        if (loggerSeparator == std::string_view::npos)
+            return LogMessageLevel::Unknown;
+
+        const size_t levelSeparator = message.find("] [", loggerSeparator + 3);
+        if (levelSeparator == std::string_view::npos)
+            return LogMessageLevel::Unknown;
+
+        const size_t levelBegin = levelSeparator + 3;
+        const size_t levelEnd = message.find(']', levelBegin);
+        if (levelEnd == std::string_view::npos)
+            return LogMessageLevel::Unknown;
+
+        const std::string_view level = message.substr(levelBegin, levelEnd - levelBegin);
+        if (level == "trace")
+            return LogMessageLevel::Trace;
+        if (level == "debug")
+            return LogMessageLevel::Debug;
+        if (level == "info")
+            return LogMessageLevel::Info;
+        if (level == "warning")
+            return LogMessageLevel::Warning;
+        if (level == "error")
+            return LogMessageLevel::Error;
+        if (level == "critical")
+            return LogMessageLevel::Critical;
+        return LogMessageLevel::Unknown;
+    }
+}
 
 void vkShade::LogPanel::render()
 {
@@ -36,7 +93,44 @@ void vkShade::LogPanel::render()
                 const char* end = begin + message.size();
                 while (end != begin && (end[-1] == '\n' || end[-1] == '\r'))
                     --end;
+
+                const ImVec4 textColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+                const ImVec4 disabledColor =
+                    ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled);
+                ImVec4 levelColor = textColor;
+                bool useLevelColor = true;
+
+                switch (log_message_level(std::string_view(begin, end)))
+                {
+                    case LogMessageLevel::Trace:
+                        levelColor = disabledColor;
+                        break;
+                    case LogMessageLevel::Debug:
+                        levelColor = blend_color(disabledColor, textColor, 0.35f);
+                        break;
+                    case LogMessageLevel::Warning:
+                        levelColor = blend_color(
+                            textColor, UIStyle::Palette::YELLOW, 0.65f);
+                        break;
+                    case LogMessageLevel::Error:
+                        levelColor = blend_color(
+                            textColor, UIStyle::Palette::RED, 0.70f);
+                        break;
+                    case LogMessageLevel::Critical:
+                        levelColor = blend_color(
+                            textColor, UIStyle::Palette::RED, 0.85f);
+                        break;
+                    case LogMessageLevel::Info:
+                    case LogMessageLevel::Unknown:
+                        useLevelColor = false;
+                        break;
+                }
+
+                if (useLevelColor)
+                    ImGui::PushStyleColor(ImGuiCol_Text, levelColor);
                 ImGui::TextUnformatted(begin, end);
+                if (useLevelColor)
+                    ImGui::PopStyleColor();
             }
         }
 

--- a/src/gui/panels/log_panel.hpp
+++ b/src/gui/panels/log_panel.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "panel.hpp"
+
+#include <string>
+#include <vector>
+
+namespace vkShade
+{
+    class LogPanel : public GuiPanel
+    {
+    public:
+        void render() override;
+
+    private:
+        std::vector<std::string> m_messages;
+        double m_nextRefresh = 0.0;
+        bool m_paused = false;
+        bool m_follow = true;
+    };
+} // namespace vkShade

--- a/src/gui/windows/main_window.cpp
+++ b/src/gui/windows/main_window.cpp
@@ -27,6 +27,12 @@ void vkShade::MainWindow::render()
                 ImGui::EndTabItem();
             }
 
+            if (ImGui::BeginTabItem("Log###log"))
+            {
+                m_logPanel.render();
+                ImGui::EndTabItem();
+            }
+
             ImGui::EndTabBar();
         }
     }

--- a/src/gui/windows/main_window.hpp
+++ b/src/gui/windows/main_window.hpp
@@ -4,6 +4,7 @@
 
 #include "config/config_store.hpp"
 #include "../panels/effects_panel.hpp"
+#include "../panels/log_panel.hpp"
 #include "../window.hpp"
 #include "about_window.hpp"
 
@@ -22,6 +23,7 @@ namespace vkShade
 
         // Panels
         EffectsPanel m_effectsPanel;
+        LogPanel     m_logPanel;
 
         // Sub-windows
         AboutWindow m_aboutWindow;


### PR DESCRIPTION
## Summary

Organize the main vkShade window into tabs and add an integrated live-log viewer.

- move the existing effect controls into an `Effects` tab
- retain up to 2,000 recent messages in the thread-safe logger
- add a `Log` tab without polling or reopening the configured log file
- provide Pause, and Follow controls
- keep the log scrollable while new messages arrive
- color complete log rows by severity using restrained, theme-relative colors
- de-emphasize trace and debug output while keeping warnings and errors easy to scan

## Testing

- rebased onto the current `main`
- release build with `meson compile -C build`
- `git diff --check`
- the live-log controls, and level coloring were smoke-tested under ETS2 via Proton/XWayland
- the configured Meson build currently contains no test targets