### PR TITLE
feat(config): implement initial ReShade preset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ This project is still in the **PRE-ALPHA** phase of development - meaning
 
 ### Limitations
 
-Some ReShade effects do not work properly yet. For example:
+Some ReShade effects and preset features do not work properly yet. For example:
 
 - Effects relying on the depth buffer
 - Effects with multiple techniques
+- ReShade's `Techniques` and `TechniqueSorting` preset parameters
 - Possibly more...
 
 ### Roadmap
@@ -55,9 +56,13 @@ Some ReShade effects do not work properly yet. For example:
 
 - [x] Chain together multiple effects
 - [x] Configuration system
-    - [x] Application-level (global) options
-    - [ ] Per-game presets using ReShade's INI format
-- [x] Basic GUI overlay (browse/apply effects and save/load config)
+    - [x] Application-level config file
+    - [x] Per-game effect presets using ReShade's INI format
+    - [ ] Hot-reload config/preset files on changes (in-progress)
+- [x] GUI overlay
+    - [x] Browse, apply, and re-order effects
+    - [x] Save and reload preset
+    - [ ] Uniform enumeration and adjustment (in-progress)
 - [x] ReShade FX integration
     - [x] Basic ReShade FX support
     - [x] Full support for ReShade's time-based runtime uniforms
@@ -173,7 +178,8 @@ ENABLE_VKSHADE=1 %command%
 
 ## Configuration
 
-The configuration file is searched for in the following locations (in order):
+The `vkShade.ini` configuration file is searched for in the following
+ locations, in order of precedence:
 
 - A file set with the environment variable
   `VKSHADE_CONFIG_FILE=/path/to/vkShade.ini`
@@ -192,13 +198,31 @@ The configuration file is searched for in the following locations (in order):
 
 ### ReShade FX
 
-To use ReShade effects, you need to configure the search paths. For example:
+To use ReShade effects, you need to configure the search paths in
+ `vkShade.ini`. For example:
 
 ```ini
 [ReShade]
 EffectSearchPaths = /opt/reshade/shaders,/opt/reshade/shaders/SweetFX
 TextureSearchPaths = /opt/reshade/textures,/opt/reshade/textures/SweetFX
 ```
+
+### ReShade Presets
+
+vkShade supports ReShade preset files (`ReShade.ini`).
+
+The preset file is searched for in the same locations as `vkShade.ini`, or a
+custom file can be specified with the `VKSHADE_PRESET_FILE` environment
+variable.
+
+Uniform values are loaded from the preset and applied to effects at runtime.
+
+> [!NOTE]
+> ReShade preset support is functional, but currently partial.
+>
+> Uniforms are fully supported, but the `Techniques` and `TechniqueSorting`
+> parameters are not supported yet. Instead, vkShade uses it's own `Effects`
+> parameter and semantics.
 
 ### Input
 

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,1 +1,2 @@
 !vkShade.ini
+!ReShade.ini

--- a/config/ReShade.ini
+++ b/config/ReShade.ini
@@ -1,0 +1,21 @@
+Effects = CRT.fx,ChromaticAberration.fx
+
+[CRT.fx]
+Overscan = 1.010000
+Angle = 0.000000,0.000000
+CurvatureRadius = 1.500000
+Curvature = false
+ScanlineIntensity = 2
+Brightness = 0.900000
+MonitorGamma = 2.200000
+Oversample = true
+ScanlineGaussian = true
+Gamma = 2.400000
+ViewerDistance = 2.000000
+CornerSize = 0.010000
+Amount = 1.000000
+Resolution = 1.150000
+
+[ChromaticAberration.fx]
+Shift = 5.000000,-5.000000
+Strength = 0.750000

--- a/config/meson.build
+++ b/config/meson.build
@@ -17,7 +17,5 @@ configure_file(
     install_dir : vulkan_layer_dir,
 )
 
-install_data(
-    'vkShade.ini',
-    install_dir: get_option('datadir') / 'vkShade'
-)
+install_data('vkShade.ini', install_dir: get_option('datadir') / 'vkShade')
+install_data('ReShade.ini', install_dir: get_option('datadir') / 'vkShade')

--- a/config/vkShade.ini
+++ b/config/vkShade.ini
@@ -1,6 +1,3 @@
-[vkShade]
-Effects = FilmicPass.fx,Daltonize.fx,Technicolor2.fx,Vibrance.fx
-
 [Input]
 ToggleEffects = KEY_INSERT
 ToggleGui = KEY_HOME

--- a/src/config/config_manager.cpp
+++ b/src/config/config_manager.cpp
@@ -5,6 +5,15 @@
 #include "config_globals.hpp"
 
 vkShade::ConfigManager::ConfigManager()
+    : m_config(ConfigStore(ConfigStore::Type::Config)),
+      m_internal(ConfigStore(ConfigStore::Type::Internal)),
+      m_preset(ConfigStore(ConfigStore::Type::Preset))
+{
+    load_config_file();
+    load_preset_file();
+}
+
+void vkShade::ConfigManager::load_config_file()
 {
     // Custom config file path
     const char* customConfigEnv  = std::getenv("VKSHADE_CONFIG_FILE");
@@ -21,7 +30,7 @@ vkShade::ConfigManager::ConfigManager()
 
     // Allowed config paths
     const std::array<std::string, 7> configCandidates = {
-        customConfigFile,                                   // Custom config (VKSHADE_CONFIG_FILE=/path/to/vkShade.conf)
+        customConfigFile,                                   // Custom config (VKSHADE_CONFIG_FILE=/path/to/vkShade.ini)
         "vkShade.ini",                                      // Per-game config
         userCustomConfigFile,                               // User custom config
         userDefaultConfigFile,                              // User default config
@@ -34,10 +43,48 @@ vkShade::ConfigManager::ConfigManager()
     {
         if (m_config.load(filePath))
         {
-            Logger::info("Loaded config file: {}", filePath);
+            // Successfully loaded candidate
             return;
         }
     }
 
     Logger::warn("No config file found");
+}
+
+void vkShade::ConfigManager::load_preset_file()
+{
+    // Custom config file path
+    const char* customPresetEnv  = std::getenv("VKSHADE_PRESET_FILE");
+    std::string customPresetFile = customPresetEnv ? std::string(customPresetEnv) : "";
+
+    // User config file path
+    const char* xdgDataEnv            = std::getenv("XDG_DATA_HOME");
+    std::string userDefaultPresetFile = xdgDataEnv ? std::string(xdgDataEnv) + "/vkShade/ReShade.ini"
+                                                   : std::string(std::getenv("HOME")) + "/.local/share/vkShade/ReShade.ini";
+
+    const char* xdgPresetEnv         = std::getenv("XDG_CONFIG_HOME");
+    std::string userCustomPresetFile = xdgPresetEnv ? std::string(xdgPresetEnv) + "/vkShade/ReShade.ini"
+                                                    : std::string(std::getenv("HOME")) + "/.config/vkShade/ReShade.ini";
+
+    // Allowed config paths
+    const std::array<std::string, 7> presetCandidates = {
+        customPresetFile,                                   // Custom preset (VKSHADE_PRESET_FILE=/path/to/ReShade.ini)
+        "ReShade.ini",                                      // Per-game preset
+        userCustomPresetFile,                               // User custom preset
+        userDefaultPresetFile,                              // User default preset
+        std::string(SYSCONFDIR) + "/ReShade.ini",           // System-wide custom preset
+        std::string(SYSCONFDIR) + "/vkShade/ReShade.ini",   // System-wide custom preset (alternative)
+        std::string(DATADIR) + "/vkShade/ReShade.ini",      // System-wide default preset
+    };
+
+    for (const auto& filePath : presetCandidates)
+    {
+        if (m_preset.load(filePath))
+        {
+            // Successfully loaded candidate
+            return;
+        }
+    }
+
+    Logger::warn("No preset file found");
 }

--- a/src/config/config_manager.hpp
+++ b/src/config/config_manager.hpp
@@ -17,5 +17,8 @@ namespace vkShade
         ConfigStore m_config;
         ConfigStore m_internal;
         ConfigStore m_preset;
+
+        void load_config_file();
+        void load_preset_file();
     };
 } // namespace vkShade

--- a/src/config/config_observer.hpp
+++ b/src/config/config_observer.hpp
@@ -53,7 +53,7 @@ namespace vkShade
             {
                 for (const auto& [ptr, pInstance, callback, reset] : it->second)
                 {
-                    callback(&value, pInstance);
+                    callback(&value, pInstance, key);
                 }
             }
         }
@@ -61,14 +61,20 @@ namespace vkShade
         // Reset each callback with a default value. Called when clearing ConfigStore.
         void notify_all_defaults()
         {
-            for (const auto& [key, handlers] : m_subscribers)
+            for (const auto& [mapKey, handlers] : m_subscribers)
+            {
+                // mapKey is "section::key" - the reset path only needs key, not section
+                size_t pos = mapKey.find("::");
+                std::string key = mapKey.substr(pos + 2);
+
                 for (const auto& [ptr, pInstance, callback, reset] : handlers)
-                    reset();
+                    reset(key);
+            }
         }
 
     private:
-        using Callback = std::function<void(const void*, void*)>;
-        using ResetCallback = std::function<void()>;
+        using Callback = std::function<void(const void*, void*, const std::string&)>;
+        using ResetCallback = std::function<void(const std::string&)>;
 
         // Map: "Section::Key" -> [(function pointer, instance pointer, callback, reset callback)]
         std::unordered_map<std::string, std::vector<std::tuple<void*, void*, Callback, ResetCallback>>> m_subscribers;
@@ -78,7 +84,7 @@ namespace vkShade
         struct function_arg;
 
         template<typename Ret, typename Arg>
-        struct function_arg<Ret(*)(Arg)>
+        struct function_arg<Ret(*)(const std::string&, Arg)>
         {
             using type = Arg;
         };
@@ -87,7 +93,7 @@ namespace vkShade
         struct method_arg;
 
         template<typename Class, typename Ret, typename Arg>
-        struct method_arg<Ret(Class::*)(Arg)>
+        struct method_arg<Ret(Class::*)(const std::string&, Arg)>
         {
             using type = Arg;
         };
@@ -110,14 +116,14 @@ namespace vkShade
                     return;  // Already connected
             }
 
-            handlers.emplace_back(pFunction, nullptr, [](const void* pValue, void*)
+            handlers.emplace_back(pFunction, nullptr, [](const void* pValue, void*, const std::string& k)
             {
-                Func(*static_cast<const ArgType*>(pValue));
+                Func(k, *static_cast<const ArgType*>(pValue));
             },
-            []()  // Reset callback - notifies with default value for the type
+            [](const std::string& k)  // Reset callback - notifies with default value for the type
             {
                 ArgType defaultValue{};
-                Func(defaultValue);
+                Func(k, defaultValue);
             });
         }
 
@@ -145,16 +151,16 @@ namespace vkShade
                     return;  // Already connected
             }
 
-            handlers.emplace_back(pMethod, instance, [](const void* pValue, void* pInstance)
+            handlers.emplace_back(pMethod, instance, [](const void* pValue, void* pInstance, const std::string& k)
             {
                 Class* obj = static_cast<Class*>(pInstance);
-                (obj->*Method)(*static_cast<const ArgType*>(pValue));
+                (obj->*Method)(k, *static_cast<const ArgType*>(pValue));
             },
-            [instance]()  // Reset callback - notifies with default value for the type
+            [instance](const std::string& k)  // Reset callback - notifies with default value for the type
             {
                 ArgType defaultValue{};
                 Class* obj = static_cast<Class*>(instance);
-                (obj->*Method)(defaultValue);
+                (obj->*Method)(k, defaultValue);
             });
         }
 

--- a/src/config/config_parser.hpp
+++ b/src/config/config_parser.hpp
@@ -43,11 +43,29 @@ namespace vkShade
             else if constexpr (std::is_integral_v<DecayedT>)
                 return parse_integer<DecayedT>(str);
             else if constexpr (std::is_same_v<DecayedT, glm::vec2>)
-                return parse_vec2(str);
+                return parse_vector<glm::vec2, 2>(str);
             else if constexpr (std::is_same_v<DecayedT, glm::vec3>)
-                return parse_vec3(str);
+                return parse_vector<glm::vec3, 3>(str);
             else if constexpr (std::is_same_v<DecayedT, glm::vec4>)
-                return parse_vec4(str);
+                return parse_vector<glm::vec4, 4>(str);
+            else if constexpr (std::is_same_v<DecayedT, glm::ivec2>)
+                return parse_vector<glm::ivec2, 2>(str);
+            else if constexpr (std::is_same_v<DecayedT, glm::ivec3>)
+                return parse_vector<glm::ivec3, 3>(str);
+            else if constexpr (std::is_same_v<DecayedT, glm::ivec4>)
+                return parse_vector<glm::ivec4, 4>(str);
+            else if constexpr (std::is_same_v<DecayedT, glm::uvec2>)
+                return parse_vector<glm::uvec2, 2>(str);
+            else if constexpr (std::is_same_v<DecayedT, glm::uvec3>)
+                return parse_vector<glm::uvec3, 3>(str);
+            else if constexpr (std::is_same_v<DecayedT, glm::uvec4>)
+                return parse_vector<glm::uvec4, 4>(str);
+            else if constexpr (std::is_same_v<DecayedT, glm::bvec2>)
+                return parse_vector<glm::bvec2, 2>(str);
+            else if constexpr (std::is_same_v<DecayedT, glm::bvec3>)
+                return parse_vector<glm::bvec3, 3>(str);
+            else if constexpr (std::is_same_v<DecayedT, glm::bvec4>)
+                return parse_vector<glm::bvec4, 4>(str);
             else
                 static_assert(always_false<T>::value, "Unsupported type for config parsing");
         }
@@ -66,6 +84,7 @@ namespace vkShade
                 return join_list(value);
             else if constexpr (std::is_same_v<DecayedT, bool>)
                 return value ? "true" : "false";
+
             else if constexpr (std::is_same_v<DecayedT, glm::vec2>)
                 return std::to_string(value.x) + "," + std::to_string(value.y);
             else if constexpr (std::is_same_v<DecayedT, glm::vec3>)
@@ -73,6 +92,36 @@ namespace vkShade
             else if constexpr (std::is_same_v<DecayedT, glm::vec4>)
                 return std::to_string(value.x) + "," + std::to_string(value.y) + "," +
                        std::to_string(value.z) + "," + std::to_string(value.w);
+
+            else if constexpr (std::is_same_v<DecayedT, glm::ivec2>)
+                return std::to_string(value.x) + "," + std::to_string(value.y);
+            else if constexpr (std::is_same_v<DecayedT, glm::ivec3>)
+                return std::to_string(value.x) + "," + std::to_string(value.y) + "," + std::to_string(value.z);
+            else if constexpr (std::is_same_v<DecayedT, glm::ivec4>)
+                return std::to_string(value.x) + "," + std::to_string(value.y) + "," +
+                       std::to_string(value.z) + "," + std::to_string(value.w);
+
+            else if constexpr (std::is_same_v<DecayedT, glm::uvec2>)
+                return std::to_string(value.x) + "," + std::to_string(value.y);
+            else if constexpr (std::is_same_v<DecayedT, glm::uvec3>)
+                return std::to_string(value.x) + "," + std::to_string(value.y) + "," + std::to_string(value.z);
+            else if constexpr (std::is_same_v<DecayedT, glm::uvec4>)
+                return std::to_string(value.x) + "," + std::to_string(value.y) + "," +
+                       std::to_string(value.z) + "," + std::to_string(value.w);
+
+            else if constexpr (std::is_same_v<DecayedT, glm::bvec2>)
+                return (value.x ? "true" : "false") + std::string(",") +
+                       (value.y ? "true" : "false");
+            else if constexpr (std::is_same_v<DecayedT, glm::bvec3>)
+                return (value.x ? "true" : "false") + std::string(",") +
+                       (value.y ? "true" : "false") + std::string(",") +
+                       (value.z ? "true" : "false");
+            else if constexpr (std::is_same_v<DecayedT, glm::bvec4>)
+                return (value.x ? "true" : "false") + std::string(",") +
+                       (value.y ? "true" : "false") + std::string(",") +
+                       (value.z ? "true" : "false") + std::string(",") +
+                       (value.w ? "true" : "false");
+
             else
                 return std::to_string(value);
         }
@@ -138,52 +187,29 @@ namespace vkShade
             }
         }
 
-        std::expected<glm::vec2, ConfigError> parse_vec2(const std::string& str) const
+        template<typename T, size_t N>
+        std::expected<T, ConfigError> parse_vector(const std::string& str) const
         {
             auto components = this->split_list(str);
-            if (components.size() != 2)
+
+            if (components.size() != N)
                 return std::unexpected(ConfigError::ParseError);
 
-            auto x = parse_float(components[0]);
-            auto y = parse_float(components[1]);
+            T result {};
 
-            if (!x || !y)
-                return std::unexpected(ConfigError::ParseError);
+            for (size_t i = 0; i < N; i++)
+            {
+                using Component = typename T::value_type;
 
-            return glm::vec2(*x, *y);
-        }
+                auto component = parse<Component>(components[i]);
 
-        std::expected<glm::vec3, ConfigError> parse_vec3(const std::string& str) const
-        {
-            auto components = this->split_list(str);
-            if (components.size() != 3)
-                return std::unexpected(ConfigError::ParseError);
+                if (!component)
+                    return std::unexpected(ConfigError::ParseError);
 
-            auto x = parse_float(components[0]);
-            auto y = parse_float(components[1]);
-            auto z = parse_float(components[2]);
+                result[i] = *component;
+            }
 
-            if (!x || !y || !z)
-                return std::unexpected(ConfigError::ParseError);
-
-            return glm::vec3(*x, *y, *z);
-        }
-
-        std::expected<glm::vec4, ConfigError> parse_vec4(const std::string& str) const
-        {
-            auto components = this->split_list(str);
-            if (components.size() != 4)
-                return std::unexpected(ConfigError::ParseError);
-
-            auto x = parse_float(components[0]);
-            auto y = parse_float(components[1]);
-            auto z = parse_float(components[2]);
-            auto w = parse_float(components[3]);
-
-            if (!x || !y || !z || !w)
-                return std::unexpected(ConfigError::ParseError);
-
-            return glm::vec4(*x, *y, *z, *w);
+            return result;
         }
 
         std::vector<std::string> split_list(const std::string& str) const

--- a/src/config/config_store.cpp
+++ b/src/config/config_store.cpp
@@ -4,6 +4,8 @@
 #include <map>
 
 #include <ini.h>
+#include <magic_enum/magic_enum.hpp>
+
 #include "core/logger.hpp"
 
 // Static callback function for inih parser
@@ -18,6 +20,13 @@ static int config_ini_handler(void* user, const char* section, const char* name,
     vkShade::Logger::trace("Parsed configuration option: {}::{} ({})", section, name, value);
 
     return 1;  // Success
+}
+
+vkShade::ConfigStore::ConfigStore(Type type)
+    : m_type(type)
+{
+    m_typeString = std::string(magic_enum::enum_name(m_type));
+    std::transform(m_typeString.begin(), m_typeString.end(), m_typeString.begin(), ::tolower);
 }
 
 void vkShade::ConfigStore::clear()
@@ -47,6 +56,8 @@ bool vkShade::ConfigStore::load(std::filesystem::path filePath)
         return false;
     }
 
+    Logger::info("Loaded {} file: {}", m_typeString, filePath.string());
+
     m_currentFile = filePath;
     return true;
 }
@@ -56,7 +67,7 @@ bool vkShade::ConfigStore::save(std::filesystem::path filePath)
     std::ofstream file(filePath);
     if (!file.is_open())
     {
-        Logger::error("Failed to open config file for writing: {}", filePath.string());
+        Logger::error("Failed to open {} file for writing: {}", m_typeString, filePath.string());
         return false;
     }
 
@@ -108,7 +119,7 @@ bool vkShade::ConfigStore::save(std::filesystem::path filePath)
     }
 
     m_currentFile = filePath;
-    Logger::trace("Saved configuration to: {}", filePath.string());
+    Logger::info("Saved {} file: {}", m_typeString, filePath.string());
     return true;
 }
 

--- a/src/config/config_store.hpp
+++ b/src/config/config_store.hpp
@@ -14,6 +14,15 @@ namespace vkShade
     class ConfigStore
     {
     public:
+        enum class Type
+        {
+            Config,
+            Internal,
+            Preset,
+        };
+
+        explicit ConfigStore(Type type);
+
         void clear();
         bool load(std::filesystem::path filePath);
         bool save(std::filesystem::path filePath);  // Save As
@@ -72,6 +81,9 @@ namespace vkShade
         }
 
     private:
+        Type m_type;
+        std::string m_typeString;
+
         ConfigParser   m_parser;
         ConfigObserver m_observer;
 

--- a/src/config/meson.build
+++ b/src/config/meson.build
@@ -15,6 +15,7 @@ libconfig_library = static_library(
   dependencies : [
     glm,
     inih,
+    magic_enum,
     spdlog,
   ],
   include_directories : vkShade_include_path

--- a/src/core/uniform.hpp
+++ b/src/core/uniform.hpp
@@ -3,19 +3,109 @@
 #include <cstdint>
 #include <string>
 
+#include <glm/glm.hpp>
+
 namespace vkShade
 {
     struct Uniform
     {
+        // The type of the uniform as understood by vkShade.
+        //
+        // This intentionally does NOT expose reshadefx::type. ReShade
+        // reflection is converted to this enum at the boundary.
         enum class Type
         {
-            Unknown = 0,
-            Float, Vec2, Vec3, Vec4,
+            Float, Float2, Float3, Float4,
+            Int,   Int2,   Int3,   Int4,
+            Uint,  Uint2,  Uint3,  Uint4,
+            Bool,  Bool2,  Bool3,  Bool4,
         };
 
         std::string name;
         uint32_t size {0};
         uint32_t offset {0};
-        Type type {Type::Unknown};
+        Type type;
+
+        // Runtime -> compile-time
+        //
+        // Uniform::Type is known only at runtime, but some operations
+        // (preset.get<T>(), on_uniform_changed<T>(), etc.) need an actual
+        // C++ type as a template argument.
+        //
+        // This function is the single place where we bridge that gap.
+        //
+        // Example:
+        //
+        //     Uniform::dispatch_type(uniform.type, [&]<typename T>(std::type_identity<T>)
+        //     {
+        //         preset.get<T>(...);
+        //     });
+        //
+        // Inside the lambda, T is the concrete C++ type corresponding
+        // to the runtime Uniform::Type.
+        template <typename Func>
+        static void dispatch_type(Type type, Func&& func)
+        {
+            switch (type)
+            {
+                case Type::Float:       return func(std::type_identity<float>{});
+                case Type::Float2:      return func(std::type_identity<glm::vec2>{});
+                case Type::Float3:      return func(std::type_identity<glm::vec3>{});
+                case Type::Float4:      return func(std::type_identity<glm::vec4>{});
+
+                case Type::Int:         return func(std::type_identity<int32_t>{});
+                case Type::Int2:        return func(std::type_identity<glm::ivec2>{});
+                case Type::Int3:        return func(std::type_identity<glm::ivec3>{});
+                case Type::Int4:        return func(std::type_identity<glm::ivec4>{});
+
+                case Type::Uint:        return func(std::type_identity<uint32_t>{});
+                case Type::Uint2:       return func(std::type_identity<glm::uvec2>{});
+                case Type::Uint3:       return func(std::type_identity<glm::uvec3>{});
+                case Type::Uint4:       return func(std::type_identity<glm::uvec4>{});
+
+                case Type::Bool:        return func(std::type_identity<bool>{});
+                case Type::Bool2:       return func(std::type_identity<glm::bvec2>{});
+                case Type::Bool3:       return func(std::type_identity<glm::bvec3>{});
+                case Type::Bool4:       return func(std::type_identity<glm::bvec4>{});
+            }
+        }
     };
+
+    // Compile-time C++ type -> runtime Uniform::Type
+    //
+    // This is the inverse of dispatch_type().
+    //
+    // For example:
+    //
+    //     uniform_type_v<float>      == Uniform::Type::Float
+    //     uniform_type_v<glm::vec3>  == Uniform::Type::Float3
+    //
+    // The primary template intentionally has no definition. If somebody
+    // tries to use an unsupported C++ type, that is a compile-time error.
+    template <typename T>
+    struct UniformType;
+
+    template <> struct UniformType<float>       : std::integral_constant<Uniform::Type, Uniform::Type::Float> {};
+    template <> struct UniformType<glm::vec2>   : std::integral_constant<Uniform::Type, Uniform::Type::Float2> {};
+    template <> struct UniformType<glm::vec3>   : std::integral_constant<Uniform::Type, Uniform::Type::Float3> {};
+    template <> struct UniformType<glm::vec4>   : std::integral_constant<Uniform::Type, Uniform::Type::Float4> {};
+
+    template <> struct UniformType<int32_t>     : std::integral_constant<Uniform::Type, Uniform::Type::Int> {};
+    template <> struct UniformType<glm::ivec2>  : std::integral_constant<Uniform::Type, Uniform::Type::Int2> {};
+    template <> struct UniformType<glm::ivec3>  : std::integral_constant<Uniform::Type, Uniform::Type::Int3> {};
+    template <> struct UniformType<glm::ivec4>  : std::integral_constant<Uniform::Type, Uniform::Type::Int4> {};
+
+    template <> struct UniformType<uint32_t>    : std::integral_constant<Uniform::Type, Uniform::Type::Uint> {};
+    template <> struct UniformType<glm::uvec2>  : std::integral_constant<Uniform::Type, Uniform::Type::Uint2> {};
+    template <> struct UniformType<glm::uvec3>  : std::integral_constant<Uniform::Type, Uniform::Type::Uint3> {};
+    template <> struct UniformType<glm::uvec4>  : std::integral_constant<Uniform::Type, Uniform::Type::Uint4> {};
+
+    template <> struct UniformType<bool>        : std::integral_constant<Uniform::Type, Uniform::Type::Bool> {};
+    template <> struct UniformType<glm::bvec2>  : std::integral_constant<Uniform::Type, Uniform::Type::Bool2> {};
+    template <> struct UniformType<glm::bvec3>  : std::integral_constant<Uniform::Type, Uniform::Type::Bool3> {};
+    template <> struct UniformType<glm::bvec4>  : std::integral_constant<Uniform::Type, Uniform::Type::Bool4> {};
+
+    // Convenient variable-template form, analogous to std::is_same_v, etc.
+    template <typename T>
+    inline constexpr Uniform::Type uniform_type_v = UniformType<T>::value;
 } // namespace vkShade

--- a/src/gui/windows/main_window.cpp
+++ b/src/gui/windows/main_window.cpp
@@ -8,6 +8,7 @@
 
 vkShade::MainWindow::MainWindow()
     : m_config(vkShade::Locator<ConfigManager>::get().app()),
+      m_preset(vkShade::Locator<ConfigManager>::get().preset()),
       m_eventBus(vkShade::Locator<EventBus>::get())
 {}
 
@@ -67,20 +68,23 @@ void vkShade::MainWindow::render_menu_bar()
         {
             if (ImGui::MenuItem("New"))
             {
-                m_config.clear();
+                m_preset.clear();
             }
 
             if (ImGui::MenuItem("Open"))
             {
                 // TODO: Open file browser and select file
-                m_config.load("vkShade.ini");  // From CWD
+                m_preset.load("ReShade.ini");  // From CWD
             }
 
             ImGui::Separator();
 
-            if (ImGui::MenuItem("Save", nullptr, nullptr, m_config.has_file()))
+            if (ImGui::MenuItem("Save", nullptr, nullptr, true))
             {
-                m_config.save();
+                if (m_preset.has_file())
+                    m_preset.save();
+                else
+                    m_preset.save("ReShade.ini");  // In CWD
             }
 
             ImGui::Separator();
@@ -120,7 +124,7 @@ void vkShade::MainWindow::render_effect_lists()
 
     // Get configured/requested effects (what the user wants active)
     std::vector<std::string> activeEffects;
-    auto activeEffectsOpt = m_config.get<std::vector<std::string>>("vkShade", "Effects");
+    auto activeEffectsOpt = m_preset.get<std::vector<std::string>>("", "Effects");
     activeEffects = activeEffectsOpt.value_or(std::vector<std::string>{});
 
     // Build a set of loaded effect names for fast lookup
@@ -219,7 +223,7 @@ void vkShade::MainWindow::render_effect_lists()
             std::string effect = availableEffects[m_selectedAvailable];
             // Add to active list
             activeEffects.push_back(effect);
-            m_config.set("vkShade", "Effects", activeEffects);
+            m_preset.set("", "Effects", activeEffects);
             m_selectedAvailable = -1;
         }
 
@@ -230,7 +234,7 @@ void vkShade::MainWindow::render_effect_lists()
         {
             // Remove from active list
             activeEffects.erase(activeEffects.begin() + m_selectedActive);
-            m_config.set("vkShade", "Effects", activeEffects);
+            m_preset.set("", "Effects", activeEffects);
             m_selectedActive = -1;
         }
 
@@ -279,7 +283,7 @@ void vkShade::MainWindow::render_effect_lists()
         if (UI::Button("Move Up", ImVec2(btnWidth, 0), canMoveUp))
         {
             std::swap(activeEffects[m_selectedActive], activeEffects[m_selectedActive - 1]);
-            m_config.set("vkShade", "Effects", activeEffects);
+            m_preset.set("", "Effects", activeEffects);
             m_selectedActive--;
         }
 
@@ -288,7 +292,7 @@ void vkShade::MainWindow::render_effect_lists()
         if (UI::Button("Move Down", ImVec2(btnWidth, 0), canMoveDown))
         {
             std::swap(activeEffects[m_selectedActive], activeEffects[m_selectedActive + 1]);
-            m_config.set("vkShade", "Effects", activeEffects);
+            m_preset.set("", "Effects", activeEffects);
             m_selectedActive++;
         }
 

--- a/src/gui/windows/main_window.hpp
+++ b/src/gui/windows/main_window.hpp
@@ -21,6 +21,7 @@ namespace vkShade
 
     private:
         ConfigStore& m_config;
+        ConfigStore& m_preset;
         EventBus&    m_eventBus;
 
         // Sub-windows

--- a/src/vk/reshade_effect.cpp
+++ b/src/vk/reshade_effect.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <ranges>
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
 
 #include <effect_parser.hpp>
@@ -23,7 +24,7 @@
 #include "vk/sampler.hpp"
 
 vkShade::ReshadeEffect::ReshadeEffect(VulkanDevice& device, VkExtent2D extent, VkFormat format, std::filesystem::path effectPath)
-    : VulkanObject(device), m_extent(extent), m_format(format)
+    : VulkanObject(device), m_extent(extent), m_format(format), m_fileName(effectPath.filename())
 {
     Logger::trace("Creating effect: {}", effectPath.filename().string());
 
@@ -43,6 +44,15 @@ vkShade::ReshadeEffect::ReshadeEffect(VulkanDevice& device, VkExtent2D extent, V
 
 vkShade::ReshadeEffect::~ReshadeEffect()
 {
+    for (const auto& [name, uniform] : m_uniformsByName)
+    {
+        auto& preset = vkShade::Locator<vkShade::ConfigManager>::get().preset();
+        Uniform::dispatch_type(uniform.type, [&]<typename T>(std::type_identity<T>)
+        {
+            preset.on_changed(m_fileName, name).disconnect<&ReshadeEffect::on_uniform_changed<T>>(this);
+        });
+    }
+
     for (const auto& pass : m_passes)
     {
         m_device.dispatch.DestroyPipeline(m_device.handle, pass.pipeline, nullptr);
@@ -404,6 +414,37 @@ VkStencilOp vkShade::ReshadeEffect::convert_stencil_op(reshadefx::stencil_op ste
     }
 
     std::unreachable();
+}
+
+vkShade::Uniform::Type vkShade::ReshadeEffect::convert_uniform_type(reshadefx::type type)
+{
+    using T = reshadefx::type;
+
+    // Float
+    if (type == T{ T::t_float, 1, 1 })  return Uniform::Type::Float;
+    if (type == T{ T::t_float, 2, 1 })  return Uniform::Type::Float2;
+    if (type == T{ T::t_float, 3, 1 })  return Uniform::Type::Float3;
+    if (type == T{ T::t_float, 4, 1 })  return Uniform::Type::Float4;
+
+    // Int
+    if (type == T{ T::t_int, 1, 1 })    return Uniform::Type::Int;
+    if (type == T{ T::t_int, 2, 1 })    return Uniform::Type::Int2;
+    if (type == T{ T::t_int, 3, 1 })    return Uniform::Type::Int3;
+    if (type == T{ T::t_int, 4, 1 })    return Uniform::Type::Int4;
+
+    // Uint
+    if (type == T{ T::t_uint, 1, 1 })   return Uniform::Type::Uint;
+    if (type == T{ T::t_uint, 2, 1 })   return Uniform::Type::Uint2;
+    if (type == T{ T::t_uint, 3, 1 })   return Uniform::Type::Uint3;
+    if (type == T{ T::t_uint, 4, 1 })   return Uniform::Type::Uint4;
+
+    // Bool
+    if (type == T{ T::t_bool, 1, 1 })   return Uniform::Type::Bool;
+    if (type == T{ T::t_bool, 2, 1 })   return Uniform::Type::Bool2;
+    if (type == T{ T::t_bool, 3, 1 })   return Uniform::Type::Bool3;
+    if (type == T{ T::t_bool, 4, 1 })   return Uniform::Type::Bool4;
+
+    throw std::invalid_argument("Unsupported uniform type");;
 }
 
 void vkShade::ReshadeEffect::reflect_descriptors()
@@ -774,20 +815,6 @@ void vkShade::ReshadeEffect::reflect_samplers()
 
 void vkShade::ReshadeEffect::reflect_uniforms()
 {
-    auto reflect_type = [](const reshadefx::type type) -> vkShade::Uniform::Type
-    {
-        if (type.base == reshadefx::type::t_float && type.rows == 1 && type.cols == 1)
-            return Uniform::Type::Float;
-        if (type.base == reshadefx::type::t_float && type.rows == 2 && type.cols == 1)
-            return Uniform::Type::Vec2;
-        if (type.base == reshadefx::type::t_float && type.rows == 3 && type.cols == 1)
-            return Uniform::Type::Vec3;
-        if (type.base == reshadefx::type::t_float && type.rows == 4 && type.cols == 1)
-            return Uniform::Type::Vec4;
-
-        return Uniform::Type::Unknown;
-    };
-
     // Convert the ReShade uniform to our own reflected type
     for (const auto& uniform : m_module->uniforms)
     {
@@ -846,20 +873,50 @@ void vkShade::ReshadeEffect::reflect_uniforms()
             }
         }
 
-        // Generic/GUI uniform
+        // If we've reached here then it's a generic/GUI uniform
+
+        // Store uniform data
         m_uniformsByName[uniform.name] = {
             .name = uniform.name,
             .size = uniform.size,
             .offset = uniform.offset,
-            .type = reflect_type(uniform.type)
+            .type = convert_uniform_type(uniform.type)
         };
 
-        // Set the default value if there is one
-        if (uniform.has_initializer_value)
+        // Subscribe to changes and set the initial value.
+        auto& preset = vkShade::Locator<vkShade::ConfigManager>::get().preset();
+        Uniform::dispatch_type(convert_uniform_type(uniform.type), [&]<typename T>(std::type_identity<T>)
         {
-            // NOTE: The initializer value is a union, so we just cast it to a pointer.
-            m_uniformBuffer->write(&uniform.initializer_value.as_uint[0], uniform.size, uniform.offset);
-        }
+            // Write the uniform value. Either from the preset, the initializer, or by zero-filling.
+            if (auto result = preset.get<T>(m_fileName, uniform.name))
+            {
+                std::string stringValue = preset.get<std::string>(m_fileName, uniform.name).value_or("");
+                Logger::trace("[{}] Loading uniform '{}' from preset: {}", m_fileName, uniform.name, stringValue);
+
+                m_uniformBuffer->write(&result.value(), uniform.size, uniform.offset);
+            }
+            else if (uniform.has_initializer_value)
+            {
+                Logger::trace("[{}] Initializing uniform '{}' from shader initializer", m_fileName, uniform.name);
+
+                T value;
+
+                // NOTE: The initializer value is a union, so we just cast it to a pointer.
+                std::memcpy(&value, &uniform.initializer_value.as_uint[0], sizeof(T));
+
+                m_uniformBuffer->write(&value, uniform.size, uniform.offset);
+                preset.set(m_fileName, uniform.name, value);
+            }
+            else
+            {
+                Logger::trace("[{}] Initializing uniform '{}' to zero", m_fileName, uniform.name);
+                std::vector<std::byte> zero(uniform.size);
+                m_uniformBuffer->write(zero.data(), zero.size(), uniform.offset);
+            }
+
+            // Subscribe to uniform changes
+            preset.on_changed(m_fileName, uniform.name).connect<&ReshadeEffect::on_uniform_changed<T>>(this);
+        });
     }
 }
 

--- a/src/vk/reshade_effect.hpp
+++ b/src/vk/reshade_effect.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <expected>
 #include <filesystem>
 #include <memory>
 
 #include <glm/glm.hpp>
 #include <vulkan/vulkan_core.h>
 
+#include "core/logger.hpp"
 #include "core/uniform.hpp"
 #include "hooks/hooks.hpp"
 #include "vk/buffer.hpp"
@@ -21,6 +21,7 @@ namespace reshadefx
     enum class stencil_func : uint8_t;
     enum class stencil_op : uint8_t;
     struct effect_module;
+    struct type;
     struct uniform;
 }
 
@@ -35,64 +36,9 @@ namespace vkShade
         ReshadeEffect(VulkanDevice& device, VkExtent2D extent, VkFormat format, std::filesystem::path effectPath);
         ~ReshadeEffect() override;
 
-        enum class Error
-        {
-            None = 0,
-            BufferNotValid,
-            UniformNotFound,
-            TypeMismatch,
-            WriteError,
-        };
-
         void apply(VkCommandBuffer cmd, VulkanImage& outputImage);
         void bind_input(VulkanImage& colorImage, VulkanImage& depthImage);
         void update(const ReshadeFrameState& frame);
-
-        template <class T>
-        std::expected<T, Error> get_uniform(const std::string& name)
-        {
-            // Search for a binding with the name passed into the func
-            const Uniform* binding = this->find_uniform(name);
-            if (!binding)
-                return std::unexpected(Error::UniformNotFound);
-
-            // Make sure the type is correct
-            if (!matches_type<T>(binding->type))
-                return std::unexpected(Error::TypeMismatch);
-
-            // Make sure the buffer is good
-            if (!m_uniformBuffer)
-                return std::unexpected(Error::BufferNotValid);
-
-            std::byte* dataStartingPoint = static_cast<std::byte*>(m_uniformBuffer->data()) + binding->offset;
-
-            // Important to reinterpret cast using T, because some stuff might be 16byte-aligned and we want to only get
-            // the bytes that correspond to the actual value type
-            return *reinterpret_cast<T*>(dataStartingPoint);
-        }
-
-        template <typename T>
-        Error set_uniform(const std::string& name, T value)
-        {
-            // Search for the uniform by name
-            const Uniform* uniform = this->find_uniform(name);
-            if (!uniform)
-                return Error::UniformNotFound;
-
-            // Make sure the type is correct
-            if (!matches_type<T>(uniform->type))
-                return Error::TypeMismatch;
-
-            // Make sure the buffer is good
-            if (!m_uniformBuffer)
-                return Error::BufferNotValid;
-
-            // Write T into the buffer at the specified offset
-            if (!m_uniformBuffer->write(&value, sizeof(T), uniform->offset))
-                return Error::WriteError;
-
-            return Error::None;
-        }
 
     private:
         struct Pass
@@ -106,8 +52,9 @@ namespace vkShade
             std::shared_ptr<ShaderModule> fragmentShader;
         };
 
-        VkExtent2D m_extent;
-        VkFormat   m_format;
+        VkExtent2D  m_extent;
+        VkFormat    m_format;
+        std::string m_fileName;
 
         std::unique_ptr<reshadefx::effect_module> m_module {nullptr};
         std::unique_ptr<VulkanBuffer> m_uniformBuffer {nullptr};
@@ -140,15 +87,38 @@ namespace vkShade
         }
 
         template<typename T>
-        bool matches_type(const Uniform::Type& type)
+        void on_uniform_changed(const std::string& name, T value)
         {
-            // Float types
-            if constexpr (std::is_same_v<T, float>)        return type == Uniform::Type::Float;
-            if constexpr (std::is_same_v<T, glm::vec2>)    return type == Uniform::Type::Vec2;
-            if constexpr (std::is_same_v<T, glm::vec3>)    return type == Uniform::Type::Vec3;
-            if constexpr (std::is_same_v<T, glm::vec4>)    return type == Uniform::Type::Vec4;
+            // Search for the uniform by name
+            const Uniform* uniform = nullptr;
+            auto it = m_uniformsByName.find(name);
+            if (it == m_uniformsByName.end())
+            {
+                Logger::error("Uniform '{}' not found", name);
+                return;
+            }
+            uniform = &it->second;
 
-            return false;
+            // Make sure the type is correct
+            if (uniform->type != uniform_type_v<T>)
+            {
+                Logger::error("Type mismatch for uniform '{}'", name);
+                return;
+            }
+
+            // Make sure the buffer is good
+            if (!m_uniformBuffer)
+            {
+                Logger::error("Uniform buffer is not valid: {}", m_fileName);
+                return;
+            }
+
+            // Write T into the buffer at the specified offset
+            if (!m_uniformBuffer->write(&value, sizeof(T), uniform->offset))
+            {
+                Logger::error("Failed to write uniform '{}'", name);
+                return;
+            }
         }
 
         void reflect_descriptors();
@@ -162,5 +132,6 @@ namespace vkShade
         static VkPrimitiveTopology convert_primitive_topology(reshadefx::primitive_topology topology);
         static VkCompareOp         convert_stencil_func(reshadefx::stencil_func stencilFunc);
         static VkStencilOp         convert_stencil_op(reshadefx::stencil_op stencilOp);
+        static Uniform::Type       convert_uniform_type(reshadefx::type type);
     };
 } // namespace vkShade

--- a/src/vk/swapchain.cpp
+++ b/src/vk/swapchain.cpp
@@ -80,13 +80,13 @@ vkShade::VulkanSwapchain::VulkanSwapchain(VulkanDevice& device, VkSwapchainKHR s
     //  own hook, not the dispatch table, to ensure the dispatch pointer fixup runs.
     VK_CHECK(vkShade_AllocateCommandBuffers(m_device.handle, &allocInfo, &m_commandBuffer));
 
-    auto& config = vkShade::Locator<vkShade::ConfigManager>::get().app();
+    auto& preset = vkShade::Locator<vkShade::ConfigManager>::get().preset();
 
     // Subscribe to config changes
-    config.on_changed("vkShade", "Effects").connect<&VulkanSwapchain::on_effects_changed>(this);
+    preset.on_changed("", "Effects").connect<&VulkanSwapchain::on_effects_changed>(this);
 
     // Load the current effects list
-    if (auto effects = config.get<std::vector<std::string>>("vkShade", "Effects"))
+    if (auto effects = preset.get<std::vector<std::string>>("", "Effects"))
     {
         this->on_effects_changed(effects.value());
     }
@@ -110,8 +110,8 @@ vkShade::VulkanSwapchain::~VulkanSwapchain()
     eventBus.sink<Events::ReloadEffects>().disconnect<&VulkanSwapchain::on_reload_effects>(this);
 
     // Unsubscribe from config changes
-    auto& config = vkShade::Locator<vkShade::ConfigManager>::get().app();
-    config.on_changed("vkShade", "Effects").disconnect<&VulkanSwapchain::on_effects_changed>(this);
+    auto& preset = vkShade::Locator<vkShade::ConfigManager>::get().preset();
+    preset.on_changed("", "Effects").disconnect<&VulkanSwapchain::on_effects_changed>(this);
 }
 
 void vkShade::VulkanSwapchain::on_effects_changed(std::vector<std::string> effects)
@@ -160,8 +160,8 @@ void vkShade::VulkanSwapchain::on_effects_changed(std::vector<std::string> effec
 
 void vkShade::VulkanSwapchain::on_reload_effects(const Events::ReloadEffects& event)
 {
-    auto& config = vkShade::Locator<vkShade::ConfigManager>::get().app();
-    auto effects = config.get<std::vector<std::string>>("vkShade", "Effects");
+    auto& preset = vkShade::Locator<vkShade::ConfigManager>::get().preset();
+    auto effects = preset.get<std::vector<std::string>>("", "Effects");
     this->on_effects_changed(effects.value_or(std::vector<std::string>{}));
 }
 

--- a/src/vk/swapchain.cpp
+++ b/src/vk/swapchain.cpp
@@ -3,6 +3,7 @@
 #include <imgui.h>
 #include <imgui_impl_vulkan.h>
 #include <magic_enum/magic_enum.hpp>
+#include <string_view>
 
 #include "config/config_manager.hpp"
 #include "core/event_bus.hpp"
@@ -88,7 +89,7 @@ vkShade::VulkanSwapchain::VulkanSwapchain(VulkanDevice& device, VkSwapchainKHR s
     // Load the current effects list
     if (auto effects = preset.get<std::vector<std::string>>("", "Effects"))
     {
-        this->on_effects_changed(effects.value());
+        this->on_effects_changed("Effects", effects.value());
     }
 
     // Subscribe to events
@@ -114,7 +115,7 @@ vkShade::VulkanSwapchain::~VulkanSwapchain()
     preset.on_changed("", "Effects").disconnect<&VulkanSwapchain::on_effects_changed>(this);
 }
 
-void vkShade::VulkanSwapchain::on_effects_changed(std::vector<std::string> effects)
+void vkShade::VulkanSwapchain::on_effects_changed(const std::string& key, std::vector<std::string> effects)
 {
     auto& config = vkShade::Locator<vkShade::ConfigManager>::get().app();
     auto searchPaths = config.get<std::vector<std::string>>("ReShade", "EffectSearchPaths");
@@ -162,7 +163,7 @@ void vkShade::VulkanSwapchain::on_reload_effects(const Events::ReloadEffects& ev
 {
     auto& preset = vkShade::Locator<vkShade::ConfigManager>::get().preset();
     auto effects = preset.get<std::vector<std::string>>("", "Effects");
-    this->on_effects_changed(effects.value_or(std::vector<std::string>{}));
+    this->on_effects_changed("Effects", effects.value_or(std::vector<std::string>{}));
 }
 
 void vkShade::VulkanSwapchain::render(uint32_t imageIndex)

--- a/src/vk/swapchain.hpp
+++ b/src/vk/swapchain.hpp
@@ -24,7 +24,7 @@ namespace vkShade
         VulkanImage& image(size_t index) const;
         uint32_t image_count() const { return m_images.size(); }
 
-        void on_effects_changed(std::vector<std::string> effects);
+        void on_effects_changed(const std::string& key, std::vector<std::string> effects);
 
         void on_reload_effects(const Events::ReloadEffects& event);
 

--- a/tests/config_observer_tests.cpp
+++ b/tests/config_observer_tests.cpp
@@ -12,22 +12,22 @@ using namespace vkShade;
 static std::vector<std::string> g_callbackLog;
 
 // Free function handlers
-void on_string_changed(const std::string& value)
+void on_string_changed(const std::string& key, const std::string& value)
 {
     g_callbackLog.push_back("string:" + value);
 }
 
-void on_float_changed(float value)
+void on_float_changed(const std::string& key, float value)
 {
     g_callbackLog.push_back("float:" + std::to_string(value));
 }
 
-void on_bool_changed(bool value)
+void on_bool_changed(const std::string& key, bool value)
 {
     g_callbackLog.push_back("bool:" + std::string(value ? "true" : "false"));
 }
 
-void on_vec3_changed(const glm::vec3& value)
+void on_vec3_changed(const std::string& key, const glm::vec3& value)
 {
     g_callbackLog.push_back("vec3:" + std::to_string(value.x) + "," +
                            std::to_string(value.y) + "," + std::to_string(value.z));
@@ -37,19 +37,19 @@ void on_vec3_changed(const glm::vec3& value)
 class TestListener
 {
 public:
-    void on_string_value(const std::string& value)
+    void on_string_value(const std::string& key, const std::string& value)
     {
         m_lastString = value;
         m_callCount++;
     }
 
-    void on_float_value(float value)
+    void on_float_value(const std::string& key, float value)
     {
         m_lastFloat = value;
         m_callCount++;
     }
 
-    void on_int_value(int32_t value)
+    void on_int_value(const std::string& key, int32_t value)
     {
         m_lastInt = value;
         m_callCount++;

--- a/tests/config_parser_tests.cpp
+++ b/tests/config_parser_tests.cpp
@@ -140,46 +140,86 @@ TEST_CASE("ConfigParser: Parse uint32_t - negative value", "[config][parser]")
     REQUIRE(result.error() == ConfigError::ParseError);
 }
 
-TEST_CASE("ConfigParser: Parse vec2", "[config][parser]")
+TEST_CASE("ConfigParser: Parse bool vectors", "[config][parser]")
 {
     ConfigParser parser;
 
-    auto result = parser.parse<glm::vec2>("1.5, 2.5");
-    REQUIRE(result.has_value());
-    REQUIRE_THAT(result->x, Catch::Matchers::WithinRel(1.5f, 0.0001f));
-    REQUIRE_THAT(result->y, Catch::Matchers::WithinRel(2.5f, 0.0001f));
+    auto vec2 = parser.parse<glm::bvec2>("true, false");
+    auto vec3 = parser.parse<glm::bvec3>("true, false, true");
+    auto vec4 = parser.parse<glm::bvec4>("false, true, false, true");
+
+    REQUIRE(vec2.has_value());
+    REQUIRE((*vec2)[0] == true);
+    REQUIRE((*vec2)[1] == false);
+
+    REQUIRE(vec3.has_value());
+    REQUIRE((*vec3)[0] == true);
+    REQUIRE((*vec3)[1] == false);
+    REQUIRE((*vec3)[2] == true);
+
+    REQUIRE(vec4.has_value());
+    REQUIRE((*vec4)[0] == false);
+    REQUIRE((*vec4)[1] == true);
+    REQUIRE((*vec4)[2] == false);
+    REQUIRE((*vec4)[3] == true);
 }
 
-TEST_CASE("ConfigParser: Parse vec2 - invalid component count", "[config][parser]")
+TEST_CASE("ConfigParser: Parse int vectors", "[config][parser]")
 {
     ConfigParser parser;
 
-    auto result = parser.parse<glm::vec2>("1.5, 2.5, 3.5");
-    REQUIRE(!result.has_value());
-    REQUIRE(result.error() == ConfigError::ParseError);
+    auto vec2 = parser.parse<glm::ivec2>("1, -2");
+    auto vec3 = parser.parse<glm::ivec3>("1, -2, 3");
+    auto vec4 = parser.parse<glm::ivec4>("1, -2, 3, -4");
+
+    REQUIRE(vec2.has_value());
+    REQUIRE((*vec2)[0] == 1);
+    REQUIRE((*vec2)[1] == -2);
+
+    REQUIRE(vec3.has_value());
+    REQUIRE((*vec3)[0] == 1);
+    REQUIRE((*vec3)[1] == -2);
+    REQUIRE((*vec3)[2] == 3);
+
+    REQUIRE(vec4.has_value());
+    REQUIRE((*vec4)[0] == 1);
+    REQUIRE((*vec4)[1] == -2);
+    REQUIRE((*vec4)[2] == 3);
+    REQUIRE((*vec4)[3] == -4);
 }
 
-TEST_CASE("ConfigParser: Parse vec3", "[config][parser]")
+TEST_CASE("ConfigParser: Parse uint vectors", "[config][parser]")
 {
     ConfigParser parser;
 
-    auto result = parser.parse<glm::vec3>("1.0, 2.0, 3.0");
-    REQUIRE(result.has_value());
-    REQUIRE_THAT(result->x, Catch::Matchers::WithinRel(1.0f, 0.0001f));
-    REQUIRE_THAT(result->y, Catch::Matchers::WithinRel(2.0f, 0.0001f));
-    REQUIRE_THAT(result->z, Catch::Matchers::WithinRel(3.0f, 0.0001f));
+    auto vec2 = parser.parse<glm::uvec2>("1, 2");
+    auto vec3 = parser.parse<glm::uvec3>("1, 2, 3");
+    auto vec4 = parser.parse<glm::uvec4>("1, 2, 3, 4");
+
+    REQUIRE(vec2.has_value());
+    REQUIRE((*vec2)[0] == 1);
+    REQUIRE((*vec2)[1] == 2);
+
+    REQUIRE(vec3.has_value());
+    REQUIRE((*vec3)[0] == 1);
+    REQUIRE((*vec3)[1] == 2);
+    REQUIRE((*vec3)[2] == 3);
+
+    REQUIRE(vec4.has_value());
+    REQUIRE((*vec4)[0] == 1);
+    REQUIRE((*vec4)[1] == 2);
+    REQUIRE((*vec4)[2] == 3);
+    REQUIRE((*vec4)[3] == 4);
 }
 
-TEST_CASE("ConfigParser: Parse vec4", "[config][parser]")
+TEST_CASE("ConfigParser: Parse vectors - invalid component count", "[config][parser]")
 {
     ConfigParser parser;
 
-    auto result = parser.parse<glm::vec4>("1.0, 2.0, 3.0, 4.0");
-    REQUIRE(result.has_value());
-    REQUIRE_THAT(result->x, Catch::Matchers::WithinRel(1.0f, 0.0001f));
-    REQUIRE_THAT(result->y, Catch::Matchers::WithinRel(2.0f, 0.0001f));
-    REQUIRE_THAT(result->z, Catch::Matchers::WithinRel(3.0f, 0.0001f));
-    REQUIRE_THAT(result->w, Catch::Matchers::WithinRel(4.0f, 0.0001f));
+    REQUIRE(!parser.parse<glm::vec2>("1.0").has_value());
+    REQUIRE(!parser.parse<glm::vec2>("1.0, 2.0, 3.0").has_value());
+    REQUIRE(!parser.parse<glm::ivec3>("1, 2").has_value());
+    REQUIRE(!parser.parse<glm::uvec4>("1, 2, 3").has_value());
 }
 
 TEST_CASE("ConfigParser: Parse string list", "[config][parser]")
@@ -231,12 +271,40 @@ TEST_CASE("ConfigParser: to_string - const char*", "[config][parser]")
     REQUIRE(result == "test");
 }
 
+TEST_CASE("ConfigParser: to_string - float", "[config][parser]")
+{
+    ConfigParser parser;
+
+    auto result = parser.to_string(3.14159f);
+
+    REQUIRE(result == "3.141590");
+}
+
+TEST_CASE("ConfigParser: to_string - int", "[config][parser]")
+{
+    ConfigParser parser;
+
+    auto result = parser.to_string(-42);
+
+    REQUIRE(result == "-42");
+}
+
+TEST_CASE("ConfigParser: to_string - uint", "[config][parser]")
+{
+    ConfigParser parser;
+
+    auto result = parser.to_string(42u);
+
+    REQUIRE(result == "42");
+}
+
 TEST_CASE("ConfigParser: to_string - bool", "[config][parser]")
 {
     ConfigParser parser;
 
     auto result1 = parser.to_string(true);
     auto result2 = parser.to_string(false);
+
     REQUIRE(result1 == "true");
     REQUIRE(result2 == "false");
 }
@@ -245,8 +313,9 @@ TEST_CASE("ConfigParser: to_string - vec2", "[config][parser]")
 {
     ConfigParser parser;
 
-    glm::vec2 v{1.5f, 2.5f};
-    auto result = parser.to_string(v);
+    glm::vec2 value {1.5f, 2.5f};
+    auto result = parser.to_string(value);
+
     REQUIRE(result == "1.500000,2.500000");
 }
 
@@ -254,9 +323,110 @@ TEST_CASE("ConfigParser: to_string - vec3", "[config][parser]")
 {
     ConfigParser parser;
 
-    glm::vec3 v{1.0f, 2.0f, 3.0f};
-    auto result = parser.to_string(v);
+    glm::vec3 value {1.0f, 2.0f, 3.0f};
+    auto result = parser.to_string(value);
+
     REQUIRE(result == "1.000000,2.000000,3.000000");
+}
+
+TEST_CASE("ConfigParser: to_string - vec4", "[config][parser]")
+{
+    ConfigParser parser;
+
+    glm::vec4 value {1.0f, 2.0f, 3.0f, 4.0f};
+    auto result = parser.to_string(value);
+
+    REQUIRE(result == "1.000000,2.000000,3.000000,4.000000");
+}
+
+TEST_CASE("ConfigParser: to_string - ivec2", "[config][parser]")
+{
+    ConfigParser parser;
+
+    glm::ivec2 value {10, -20};
+    auto result = parser.to_string(value);
+
+    REQUIRE(result == "10,-20");
+}
+
+TEST_CASE("ConfigParser: to_string - ivec3", "[config][parser]")
+{
+    ConfigParser parser;
+
+    glm::ivec3 value {10, -20, 30};
+    auto result = parser.to_string(value);
+
+    REQUIRE(result == "10,-20,30");
+}
+
+TEST_CASE("ConfigParser: to_string - ivec4", "[config][parser]")
+{
+    ConfigParser parser;
+
+    glm::ivec4 value {10, -20, 30, -40};
+    auto result = parser.to_string(value);
+
+    REQUIRE(result == "10,-20,30,-40");
+}
+
+TEST_CASE("ConfigParser: to_string - uvec2", "[config][parser]")
+{
+    ConfigParser parser;
+
+    glm::uvec2 value {10u, 20u};
+    auto result = parser.to_string(value);
+
+    REQUIRE(result == "10,20");
+}
+
+TEST_CASE("ConfigParser: to_string - uvec3", "[config][parser]")
+{
+    ConfigParser parser;
+
+    glm::uvec3 value {10u, 20u, 30u};
+    auto result = parser.to_string(value);
+
+    REQUIRE(result == "10,20,30");
+}
+
+TEST_CASE("ConfigParser: to_string - uvec4", "[config][parser]")
+{
+    ConfigParser parser;
+
+    glm::uvec4 value {10u, 20u, 30u, 40u};
+    auto result = parser.to_string(value);
+
+    REQUIRE(result == "10,20,30,40");
+}
+
+TEST_CASE("ConfigParser: to_string - bvec2", "[config][parser]")
+{
+    ConfigParser parser;
+
+    glm::bvec2 value {true, false};
+    auto result = parser.to_string(value);
+
+    REQUIRE(result == "true,false");
+}
+
+TEST_CASE("ConfigParser: to_string - bvec3", "[config][parser]")
+{
+    ConfigParser parser;
+
+    glm::bvec3 value {true, false, true};
+    auto result = parser.to_string(value);
+
+    REQUIRE(result == "true,false,true");
+}
+
+TEST_CASE("ConfigParser: to_string - bvec4", "[config][parser]")
+{
+    ConfigParser parser;
+
+    glm::bvec4 value {true, false, true, false};
+    auto result = parser.to_string(value);
+
+    REQUIRE(result == "true,false,true,false");
 }
 
 TEST_CASE("ConfigParser: to_string - string list", "[config][parser]")

--- a/tests/config_store_tests.cpp
+++ b/tests/config_store_tests.cpp
@@ -46,7 +46,7 @@ private:
 
 TEST_CASE("ConfigStore: Set and get string", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     config.set("app", "name", std::string("MyApp"));
     auto result = config.get<std::string>("app", "name");
@@ -57,7 +57,7 @@ TEST_CASE("ConfigStore: Set and get string", "[config][manager]")
 
 TEST_CASE("ConfigStore: Set and get with string literal", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     config.set("app", "title", "Hello World");
     auto result = config.get<std::string>("app", "title");
@@ -68,7 +68,7 @@ TEST_CASE("ConfigStore: Set and get with string literal", "[config][manager]")
 
 TEST_CASE("ConfigStore: Set and get float", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     config.set("audio", "volume", 0.75f);
     auto result = config.get<float>("audio", "volume");
@@ -79,7 +79,7 @@ TEST_CASE("ConfigStore: Set and get float", "[config][manager]")
 
 TEST_CASE("ConfigStore: Set and get bool", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     config.set("graphics", "vsync", true);
     auto result = config.get<bool>("graphics", "vsync");
@@ -90,7 +90,7 @@ TEST_CASE("ConfigStore: Set and get bool", "[config][manager]")
 
 TEST_CASE("ConfigStore: Set and get int32_t", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     config.set("graphics", "width", 1920);
     auto result = config.get<int32_t>("graphics", "width");
@@ -101,7 +101,7 @@ TEST_CASE("ConfigStore: Set and get int32_t", "[config][manager]")
 
 TEST_CASE("ConfigStore: Set and get uint32_t", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     config.set("graphics", "samples", 4u);
     auto result = config.get<uint32_t>("graphics", "samples");
@@ -112,7 +112,7 @@ TEST_CASE("ConfigStore: Set and get uint32_t", "[config][manager]")
 
 TEST_CASE("ConfigStore: Set and get vec3", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     glm::vec3 color{0.5f, 0.75f, 1.0f};
     config.set("graphics", "skyColor", color);
@@ -126,7 +126,7 @@ TEST_CASE("ConfigStore: Set and get vec3", "[config][manager]")
 
 TEST_CASE("ConfigStore: Set and get string list", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     std::vector<std::string> maps = {"map1", "map2", "map3"};
     config.set("game", "maps", maps);
@@ -141,7 +141,7 @@ TEST_CASE("ConfigStore: Set and get string list", "[config][manager]")
 
 TEST_CASE("ConfigStore: Get non-existent key", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     auto result = config.get<std::string>("nonexistent", "key");
 
@@ -151,7 +151,7 @@ TEST_CASE("ConfigStore: Get non-existent key", "[config][manager]")
 
 TEST_CASE("ConfigStore: Get with wrong type", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     config.set("test", "value", std::string("not a number"));
     auto result = config.get<float>("test", "value");
@@ -162,7 +162,7 @@ TEST_CASE("ConfigStore: Get with wrong type", "[config][manager]")
 
 TEST_CASE("ConfigStore: Update existing value", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     config.set("test", "counter", 1);
     config.set("test", "counter", 2);
@@ -176,7 +176,7 @@ TEST_CASE("ConfigStore: Update existing value", "[config][manager]")
 TEST_CASE("ConfigStore: Save to file", "[config][manager]")
 {
     TempConfigFile tempFile("test_save.ini");
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     config.set("graphics", "width", 1920);
     config.set("graphics", "height", 1080);
@@ -205,7 +205,7 @@ TEST_CASE("ConfigStore: Load from file", "[config][manager]")
         "volume = 0.75\n"
     );
 
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
     config.load(tempFile.path());
 
     auto width = config.get<int32_t>("graphics", "width");
@@ -225,7 +225,7 @@ TEST_CASE("ConfigStore: Load from file", "[config][manager]")
 
 TEST_CASE("ConfigStore: Load non-existent file does nothing", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
     config.set("test", "value", std::string("original"));
 
     config.load("/nonexistent/path/config.ini");
@@ -240,7 +240,7 @@ TEST_CASE("ConfigStore: Save and load round-trip", "[config][manager]")
     TempConfigFile tempFile("test_roundtrip.ini");
 
     {
-        ConfigStore config;
+        ConfigStore config(ConfigStore::Type::Internal);
         config.set("graphics", "width", 2560);
         config.set("graphics", "height", 1440);
         config.set("graphics", "vsync", false);
@@ -251,7 +251,7 @@ TEST_CASE("ConfigStore: Save and load round-trip", "[config][manager]")
     }
 
     {
-        ConfigStore config;
+        ConfigStore config(ConfigStore::Type::Internal);
         config.load(tempFile.path());
 
         REQUIRE(*config.get<int32_t>("graphics", "width") == 2560);
@@ -266,7 +266,7 @@ TEST_CASE("ConfigStore: Save and load round-trip", "[config][manager]")
 TEST_CASE("ConfigStore: Section ordering - unnamed first, vkShade second, then alphabetical", "[config][manager]")
 {
     TempConfigFile tempFile("test_ordering.ini");
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     config.set("", "global", std::string("value"));
     config.set("zebra", "last", std::string("z"));
@@ -293,7 +293,7 @@ TEST_CASE("ConfigStore: Section ordering - unnamed first, vkShade second, then a
 TEST_CASE("ConfigStore: No trailing newline after last section", "[config][manager]")
 {
     TempConfigFile tempFile("test_no_trailing.ini");
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     config.set("section1", "key", std::string("value"));
     config.set("section2", "key", std::string("value"));
@@ -317,7 +317,7 @@ TEST_CASE("ConfigStore: No trailing newline after last section", "[config][manag
 TEST_CASE("ConfigStore: Unnamed section appears first", "[config][manager]")
 {
     TempConfigFile tempFile("test_unnamed.ini");
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
 
     config.set("", "global_key", std::string("global_value"));
     config.set("vkShade", "app_key", std::string("app_value"));
@@ -343,7 +343,7 @@ TEST_CASE("ConfigStore: Load with vec3", "[config][manager]")
         "color = 1.0, 0.5, 0.25\n"
     );
 
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
     config.load(tempFile.path());
 
     auto color = config.get<glm::vec3>("graphics", "color");
@@ -361,7 +361,7 @@ TEST_CASE("ConfigStore: Load with string list", "[config][manager]")
         "maps = map1, map2, map3\n"
     );
 
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
     config.load(tempFile.path());
 
     auto maps = config.get<std::vector<std::string>>("game", "maps");
@@ -374,7 +374,7 @@ TEST_CASE("ConfigStore: Load with string list", "[config][manager]")
 
 TEST_CASE("ConfigStore: save() with no current file returns false", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
     config.set("test", "key", std::string("value"));
 
     REQUIRE(config.save() == false);
@@ -388,13 +388,13 @@ TEST_CASE("ConfigStore: load sets current file for subsequent save()", "[config]
         "width = 1920\n"
     );
 
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
     REQUIRE(config.load(tempFile.path()) == true);
 
     config.set("graphics", "width", 2560);
     REQUIRE(config.save() == true);
 
-    ConfigStore config2;
+    ConfigStore config2(ConfigStore::Type::Internal);
     config2.load(tempFile.path());
     REQUIRE(*config2.get<int32_t>("graphics", "width") == 2560);
 }
@@ -402,7 +402,7 @@ TEST_CASE("ConfigStore: load sets current file for subsequent save()", "[config]
 TEST_CASE("ConfigStore: explicit save() path sets current file", "[config][manager]")
 {
     TempConfigFile tempFile("test_setcurrentfile.ini");
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
     config.set("test", "key", std::string("value"));
 
     REQUIRE(config.save(tempFile.path()) == true);
@@ -410,14 +410,14 @@ TEST_CASE("ConfigStore: explicit save() path sets current file", "[config][manag
     config.set("test", "key", std::string("updated"));
     REQUIRE(config.save() == true);
 
-    ConfigStore config2;
+    ConfigStore config2(ConfigStore::Type::Internal);
     config2.load(tempFile.path());
     REQUIRE(*config2.get<std::string>("test", "key") == "updated");
 }
 
 TEST_CASE("ConfigStore: has_file() returns false by default", "[config][manager]")
 {
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
     REQUIRE(config.has_file() == false);
 }
 
@@ -426,7 +426,7 @@ TEST_CASE("ConfigStore: has_file() returns true after load", "[config][manager]"
     TempConfigFile tempFile("test_haspath_load.ini");
     tempFile.write("[test]\nkey = value\n");
 
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
     config.load(tempFile.path());
     REQUIRE(config.has_file() == true);
 }
@@ -434,7 +434,7 @@ TEST_CASE("ConfigStore: has_file() returns true after load", "[config][manager]"
 TEST_CASE("ConfigStore: has_file() returns true after save with path", "[config][manager]")
 {
     TempConfigFile tempFile("test_haspath_save.ini");
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
     config.set("test", "key", std::string("value"));
     config.save(tempFile.path());
     REQUIRE(config.has_file() == true);
@@ -445,7 +445,7 @@ TEST_CASE("ConfigStore: clear() resets config and current file", "[config][manag
     TempConfigFile tempFile("test_clear.ini");
     tempFile.write("[test]\nkey = value\n");
 
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
     config.load(tempFile.path());
     config.clear();
 
@@ -458,7 +458,7 @@ TEST_CASE("ConfigStore: save() returns false after clear()", "[config][manager]"
     TempConfigFile tempFile("test_clear_save.ini");
     tempFile.write("[test]\nkey = value\n");
 
-    ConfigStore config;
+    ConfigStore config(ConfigStore::Type::Internal);
     config.load(tempFile.path());
     config.clear();
 


### PR DESCRIPTION
## Summary

Implement initial support for ReShade preset files.

- Search for `ReShade.ini` in the same paths as `vkShade.ini`.
- Support the `VKSHADE_PRESET_FILE` environment variable for custom files.
- Determine initial uniform values using the following order of precedence:
    1. Value from the preset file.
    2. Shader-defined initializer.
    3. Zero-filled fallback.
- Subscribe effects to uniform changes in the `preset` key-value store.
- Support scalar and vector forms of float, int, uint, and bool.

### ReShade Compatibility

ReShade preset support is functional, but currently partial.

- Uniforms are fully supported.
- The `Techniques` and `TechniqueSorting` parameters are currently unsupported. Instead, vkShade uses its own `Effects` parameter and semantics.
- All other parameters are currently unsupported.

## Testing

Tests have been adjusted and expanded to match config system changes.

All tests pass. Every commit compiles.