### PR TITLE
feat(config): add config and preset hot-reloading

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
             --enable=information,warning,style,performance,portability \
             --check-level=exhaustive \
             --std=c++23 \
+            -D__linux__ \
             -D__GNUC__=4 \
             -i subprojects \
             --suppress="*:subprojects/*" \

--- a/src/config/config_manager.cpp
+++ b/src/config/config_manager.cpp
@@ -1,6 +1,7 @@
 #include "config_manager.hpp"
 
 #include "core/logger.hpp"
+#include "platform/file_watcher.hpp"
 
 #include "config_globals.hpp"
 
@@ -44,6 +45,8 @@ void vkShade::ConfigManager::load_config_file()
         if (m_config.load(filePath))
         {
             // Successfully loaded candidate
+            m_configWatcher = Platform::FileWatcher::create();
+            m_configWatcher->watch(filePath);
             return;
         }
     }
@@ -82,9 +85,28 @@ void vkShade::ConfigManager::load_preset_file()
         if (m_preset.load(filePath))
         {
             // Successfully loaded candidate
+            m_presetWatcher = Platform::FileWatcher::create();
+            m_presetWatcher->watch(filePath);
             return;
         }
     }
 
     Logger::warn("No preset file found");
+}
+
+void vkShade::ConfigManager::update()
+{
+    if (m_configWatcher && m_configWatcher->changed())
+    {
+        auto filePath = m_config.get_path();
+        if (!filePath.empty())
+            m_config.load(filePath);
+    }
+
+    if (m_presetWatcher && m_presetWatcher->changed())
+    {
+        auto filePath = m_preset.get_path();
+        if (!filePath.empty())
+            m_preset.load(filePath);
+    }
 }

--- a/src/config/config_manager.hpp
+++ b/src/config/config_manager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "config_store.hpp"
+#include "platform/file_watcher.hpp"
 
 namespace vkShade
 {
@@ -13,10 +14,15 @@ namespace vkShade
         ConfigStore& internal() { return m_internal; }
         ConfigStore& preset() { return m_preset; }
 
+        void update();
+
     private:
         ConfigStore m_config;
         ConfigStore m_internal;
         ConfigStore m_preset;
+
+        std::unique_ptr<Platform::FileWatcher> m_configWatcher;
+        std::unique_ptr<Platform::FileWatcher> m_presetWatcher;
 
         void load_config_file();
         void load_preset_file();

--- a/src/config/config_observer.hpp
+++ b/src/config/config_observer.hpp
@@ -8,6 +8,8 @@
 
 namespace vkShade
 {
+    class ConfigStore;
+
     class ConfigObserver
     {
     public:
@@ -51,33 +53,37 @@ namespace vkShade
             auto it = m_subscribers.find(mapKey);
             if (it != m_subscribers.end())
             {
-                for (const auto& [ptr, pInstance, callback, reset] : it->second)
+                for (const auto& subscription : it->second)
                 {
-                    callback(&value, pInstance, key);
+                    subscription.callback(&value, subscription.instance, key);
                 }
             }
         }
 
-        // Reset each callback with a default value. Called when clearing ConfigStore.
-        void notify_all_defaults()
+        void notify_all(ConfigStore& store)
         {
-            for (const auto& [mapKey, handlers] : m_subscribers)
-            {
-                // mapKey is "section::key" - the reset path only needs key, not section
-                size_t pos = mapKey.find("::");
-                std::string key = mapKey.substr(pos + 2);
-
-                for (const auto& [ptr, pInstance, callback, reset] : handlers)
-                    reset(key);
-            }
+            for (auto& [_, subscriptions] : m_subscribers)
+                for (auto& subscription : subscriptions)
+                    subscription.reload(store);
         }
 
     private:
         using Callback = std::function<void(const void*, void*, const std::string&)>;
-        using ResetCallback = std::function<void(const std::string&)>;
 
-        // Map: "Section::Key" -> [(function pointer, instance pointer, callback, reset callback)]
-        std::unordered_map<std::string, std::vector<std::tuple<void*, void*, Callback, ResetCallback>>> m_subscribers;
+        struct Subscription
+        {
+            std::string section;
+            std::string key;
+
+            void* function;
+            void* instance;
+
+            Callback callback;
+            std::function<void(ConfigStore&)> reload;
+        };
+
+        // Map: "Section::Key" -> [Subscription]
+        std::unordered_map<std::string, std::vector<Subscription>> m_subscribers;
 
         // Helper traits
         template<typename T>
@@ -100,128 +106,18 @@ namespace vkShade
 
         // Connect free function
         template<auto Func>
-        void connect_impl(const std::string& section, const std::string& key)
-        {
-            using FuncType = decltype(Func);
-            using ArgType = std::decay_t<typename function_arg<FuncType>::type>;
-
-            std::string mapKey = section + "::" + key;
-            void* pFunction = reinterpret_cast<void*>(Func);
-
-            // Check if already connected
-            auto& handlers = m_subscribers[mapKey];
-            for (const auto& [ptr, pInstance, callback, reset] : handlers)
-            {
-                if (ptr == pFunction && pInstance == nullptr)
-                    return;  // Already connected
-            }
-
-            handlers.emplace_back(pFunction, nullptr, [](const void* pValue, void*, const std::string& k)
-            {
-                Func(k, *static_cast<const ArgType*>(pValue));
-            },
-            [](const std::string& k)  // Reset callback - notifies with default value for the type
-            {
-                ArgType defaultValue{};
-                Func(k, defaultValue);
-            });
-        }
+        void connect_impl(const std::string& section, const std::string& key);
 
         // Connect member function
         template<auto Method, typename Class>
-        void connect_impl(const std::string& section, const std::string& key, Class* instance)
-        {
-            using MethodType = decltype(Method);
-            using ArgType = std::decay_t<typename method_arg<MethodType>::type>;
-
-            std::string mapKey = section + "::" + key;
-
-            union {
-                MethodType method;
-                void* ptr;
-            } converter;
-            converter.method = Method;
-            void* pMethod = converter.ptr;
-
-            // Check if already connected
-            auto& handlers = m_subscribers[mapKey];
-            for (const auto& [ptr, pInstance, callback, reset] : handlers)
-            {
-                if (ptr == pMethod && pInstance == instance)
-                    return;  // Already connected
-            }
-
-            handlers.emplace_back(pMethod, instance, [](const void* pValue, void* pInstance, const std::string& k)
-            {
-                Class* obj = static_cast<Class*>(pInstance);
-                (obj->*Method)(k, *static_cast<const ArgType*>(pValue));
-            },
-            [instance](const std::string& k)  // Reset callback - notifies with default value for the type
-            {
-                ArgType defaultValue{};
-                Class* obj = static_cast<Class*>(instance);
-                (obj->*Method)(k, defaultValue);
-            });
-        }
+        void connect_impl(const std::string& section, const std::string& key, Class* instance);
 
         // Disconnect free function
         template<auto Func>
-        void disconnect_impl(const std::string& section, const std::string& key)
-        {
-            std::string mapKey = section + "::" + key;
-            void* pFunction = reinterpret_cast<void*>(Func);
-
-            auto it = m_subscribers.find(mapKey);
-            if (it != m_subscribers.end())
-            {
-                auto& handlers = it->second;
-                handlers.erase(std::remove_if(handlers.begin(), handlers.end(),
-                    [pFunction](const auto& tuple)
-                    {
-                        return std::get<0>(tuple) == pFunction && std::get<1>(tuple) == nullptr;
-                    }),
-                    handlers.end()
-                );
-
-                // Clean up empty entries
-                if (handlers.empty())
-                {
-                    m_subscribers.erase(it);
-                }
-            }
-        }
+        void disconnect_impl(const std::string& section, const std::string& key);
 
         // Disconnect member function
         template<auto Method, typename Class>
-        void disconnect_impl(const std::string& section, const std::string& key, Class* instance)
-        {
-            std::string mapKey = section + "::" + key;
-
-            union {
-                decltype(Method) method;
-                void* ptr;
-            } converter;
-            converter.method = Method;
-            void* pMethod = converter.ptr;
-
-            auto it = m_subscribers.find(mapKey);
-            if (it != m_subscribers.end())
-            {
-                auto& handlers = it->second;
-                handlers.erase(std::remove_if(handlers.begin(), handlers.end(),
-                    [pMethod, instance](const auto& tuple)
-                    {
-                        return std::get<0>(tuple) == pMethod && std::get<1>(tuple) == instance;
-                    }),
-                    handlers.end()
-                );
-
-                // Clean up empty entries
-                if (handlers.empty())
-                {
-                    m_subscribers.erase(it);
-                }
-            }
-        }
+        void disconnect_impl(const std::string& section, const std::string& key, Class* instance);
     };
 } // namespace vkShade

--- a/src/config/config_observer.inl
+++ b/src/config/config_observer.inl
@@ -1,0 +1,163 @@
+#pragma once
+
+#include "config_observer.hpp"
+#include "config_store.hpp"
+
+// This file must only be included from config_store.hpp, AFTER
+// class ConfigStore is fully defined. connect_impl's body calls
+// ConfigStore::get<T>(), which requires the complete type.
+//
+// Do not include this file directly.
+
+namespace vkShade
+{
+    // Connect free function
+    template<auto Func>
+    void ConfigObserver::connect_impl(const std::string& section, const std::string& key)
+    {
+        using FuncType = decltype(Func);
+        using ArgType = std::decay_t<typename function_arg<FuncType>::type>;
+
+        std::string mapKey = section + "::" + key;
+        void* pFunction = reinterpret_cast<void*>(Func);
+
+        // Check if already connected
+        auto& handlers = m_subscribers[mapKey];
+        for (const auto& sub : handlers)
+        {
+            if (sub.function == pFunction && sub.instance == nullptr)
+                return;  // Already connected
+        }
+
+        // If not, create a new subscription.
+        Subscription subscription;
+
+        subscription.section = section;
+        subscription.key = key;
+        subscription.function = pFunction;
+        subscription.instance = nullptr;
+
+        subscription.callback = [](const void* pValue, void*, const std::string& k)
+        {
+            Func(k, *static_cast<const ArgType*>(pValue));
+        };
+
+        subscription.reload = [section, key](ConfigStore& store)
+        {
+            auto value = store.get<ArgType>(section, key);
+
+            if (value)
+                Func(key, *value);
+        };
+
+        handlers.push_back(std::move(subscription));
+    }
+
+    // Connect member function
+    template<auto Method, typename Class>
+    void ConfigObserver::connect_impl(const std::string& section, const std::string& key, Class* instance)
+    {
+        using MethodType = decltype(Method);
+        using ArgType = std::decay_t<typename method_arg<MethodType>::type>;
+
+        std::string mapKey = section + "::" + key;
+
+        union {
+            MethodType method;
+            void* ptr;
+        } converter;
+        converter.method = Method;
+        void* pMethod = converter.ptr;
+
+        // Check if already connected
+        auto& handlers = m_subscribers[mapKey];
+        for (const auto& sub : handlers)
+        {
+            if (sub.function == pMethod && sub.instance == instance)
+                return;  // Already connected
+        }
+
+        // If not then create a new subscription
+        Subscription subscription;
+
+        subscription.section = section;
+        subscription.key = key;
+        subscription.function = pMethod;
+        subscription.instance = instance;
+
+        subscription.callback = [](const void* pValue, void* pInstance, const std::string& k)
+        {
+            Class* obj = static_cast<Class*>(pInstance);
+            (obj->*Method)(k, *static_cast<const ArgType*>(pValue));
+        };
+
+        subscription.reload = [instance, section, key](ConfigStore& store)
+        {
+            auto value = store.get<ArgType>(section, key);
+            if (value)
+                (instance->*Method)(key, *value);
+        };
+
+        handlers.push_back(std::move(subscription));
+    }
+
+    // Disconnect free function
+    template<auto Func>
+    void ConfigObserver::disconnect_impl(const std::string& section, const std::string& key)
+    {
+        std::string mapKey = section + "::" + key;
+        void* pFunction = reinterpret_cast<void*>(Func);
+
+        auto it = m_subscribers.find(mapKey);
+        if (it != m_subscribers.end())
+        {
+            auto& handlers = it->second;
+            handlers.erase(std::remove_if(handlers.begin(), handlers.end(),
+                [pFunction](const Subscription& sub)
+                {
+                    return sub.function == pFunction && sub.instance == nullptr;
+                }),
+                handlers.end()
+            );
+
+            // Clean up empty entries
+            if (handlers.empty())
+            {
+                m_subscribers.erase(it);
+            }
+        }
+    }
+
+    // Disconnect member function
+    template<auto Method, typename Class>
+    void ConfigObserver::disconnect_impl(const std::string& section, const std::string& key, Class* instance)
+    {
+        std::string mapKey = section + "::" + key;
+
+        union {
+            decltype(Method) method;
+            void* ptr;
+        } converter;
+        converter.method = Method;
+        void* pMethod = converter.ptr;
+
+        auto it = m_subscribers.find(mapKey);
+        if (it != m_subscribers.end())
+        {
+            auto& handlers = it->second;
+            handlers.erase(std::remove_if(handlers.begin(), handlers.end(),
+                [pMethod, instance](const Subscription& sub)
+                {
+                    return sub.function == pMethod && sub.instance == instance;
+                }),
+                handlers.end()
+            );
+
+            // Clean up empty entries
+            if (handlers.empty())
+            {
+                m_subscribers.erase(it);
+            }
+        }
+    }
+} // namespace vkShade

--- a/src/config/config_store.cpp
+++ b/src/config/config_store.cpp
@@ -31,9 +31,9 @@ vkShade::ConfigStore::ConfigStore(Type type)
 
 void vkShade::ConfigStore::clear()
 {
-    m_observer.notify_all_defaults();
     m_currentFile = std::filesystem::path{};
     m_config.clear();
+    m_observer.notify_all(*this);
 }
 
 bool vkShade::ConfigStore::load(std::filesystem::path filePath)
@@ -48,6 +48,9 @@ bool vkShade::ConfigStore::load(std::filesystem::path filePath)
     if ((perms & std::filesystem::perms::owner_read) == std::filesystem::perms::none)
         return false;
 
+    // Clear existing state if there is any
+    this->clear();
+
     // Parse the INI file
     int result = ini_parse(filePath.string().c_str(), config_ini_handler, &m_config);
     if (result != 0)
@@ -55,6 +58,8 @@ bool vkShade::ConfigStore::load(std::filesystem::path filePath)
         Logger::error("Failed to load or parse config file: {}", filePath.c_str());
         return false;
     }
+
+    m_observer.notify_all(*this);
 
     Logger::info("Loaded {} file: {}", m_typeString, filePath.string());
 

--- a/src/config/config_store.hpp
+++ b/src/config/config_store.hpp
@@ -29,6 +29,7 @@ namespace vkShade
         bool save();  // Save currently open file
 
         bool has_file() const { return !m_currentFile.empty(); }
+        std::filesystem::path get_path() const { return m_currentFile; }
 
         // Typed getter
         template<typename T>

--- a/src/config/config_store.hpp
+++ b/src/config/config_store.hpp
@@ -91,3 +91,5 @@ namespace vkShade
         std::unordered_map<std::string, std::string> m_config;
     };
 } // namespace vkShade
+
+#include "config_observer.inl"

--- a/src/config/meson.build
+++ b/src/config/meson.build
@@ -15,6 +15,7 @@ libconfig_library = static_library(
   dependencies : [
     glm,
     inih,
+    libplatform,
     magic_enum,
     spdlog,
   ],

--- a/src/hooks/hooks_swapchain.cpp
+++ b/src/hooks/hooks_swapchain.cpp
@@ -5,6 +5,8 @@
 #include <imgui.h>
 #include <imgui_impl_vulkan.h>
 #include <vulkan/vulkan_core.h>
+
+#include "config/config_manager.hpp"
 #include "core/logger.hpp"
 #include "core/service_locator.hpp"
 #include "input/input_manager.hpp"
@@ -79,11 +81,13 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_QueuePresentKHR(VkQueue queue, const
         vkShade::Locator<vkShade::GuiManager>::emplace(thisDevice, swapchainData->format());
 
     // Get manager handles
+    auto& configManager = vkShade::Locator<vkShade::ConfigManager>::get();
     auto& input = vkShade::Locator<vkShade::InputManager>::get();
     auto& gui = vkShade::Locator<vkShade::GuiManager>::get();
     auto& eventBus = vkShade::Locator<vkShade::EventBus>::get();
 
     // Update managers
+    configManager.update();
     eventBus.update();
     input.update();
 

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -54,16 +54,18 @@ vkShade::InputManager::InputManager()
         auto toggleEffects = config.get<std::string>("Input", "ToggleEffects");
         vkShade::KeyCode keyEnum;
         std::string keyString = toggleEffects.value_or("");
-        keyEnum = magic_enum::enum_cast<vkShade::KeyCode>(keyString).value_or(vkShade::KeyCode::KEY_INSERT);
+        keyEnum = magic_enum::enum_cast<vkShade::KeyCode>(keyString).value_or(DEFAULT_KEY_EFFECTS_TOGGLE);
         bind_action("ToggleEffects", keyEnum);
+        config.on_changed("Input", "ToggleEffects").connect<&InputManager::on_keybind_changed>(this);
     }
 
     {
         auto toggleGui = config.get<std::string>("Input", "ToggleGui");
         vkShade::KeyCode keyEnum;
         std::string keyString = toggleGui.value_or("");
-        keyEnum = magic_enum::enum_cast<vkShade::KeyCode>(keyString).value_or(vkShade::KeyCode::KEY_HOME);
+        keyEnum = magic_enum::enum_cast<vkShade::KeyCode>(keyString).value_or(DEFAULT_KEY_GUI_TOGGLE);
         bind_action("ToggleGui", keyEnum);
+        config.on_changed("Input", "ToggleGui").connect<&InputManager::on_keybind_changed>(this);
     }
 }
 
@@ -254,6 +256,19 @@ vkShade::KeyCode vkShade::InputManager::map_key(xkb_keysym_t keysym)
         case XKB_KEY_F12:          return KeyCode::KEY_F12;
         default:                   return KeyCode::KEY_UNKNOWN;
     }
+}
+
+void vkShade::InputManager::on_keybind_changed(const std::string& configKey, std::string enumString)
+{
+    auto enumResult = magic_enum::enum_cast<KeyCode>(enumString);
+
+    vkShade::KeyCode keyEnum;
+    if (configKey == "ToggleEffects")
+        keyEnum = enumResult.value_or(DEFAULT_KEY_EFFECTS_TOGGLE);
+    if (configKey == "ToggleGui")
+        keyEnum = enumResult.value_or(DEFAULT_KEY_GUI_TOGGLE);
+
+    bind_action(configKey, keyEnum);
 }
 
 void vkShade::InputManager::update()

--- a/src/input/input_manager.hpp
+++ b/src/input/input_manager.hpp
@@ -15,6 +15,9 @@ typedef uint32_t xkb_keysym_t;
 
 namespace vkShade
 {
+    constexpr KeyCode DEFAULT_KEY_EFFECTS_TOGGLE = KeyCode::KEY_INSERT;
+    constexpr KeyCode DEFAULT_KEY_GUI_TOGGLE = KeyCode::KEY_HOME;
+
     class InputManager
     {
     public:
@@ -48,6 +51,8 @@ namespace vkShade
         void handle_keyboard_event(const xkb_keysym_t& keysym, bool pressed);
         void handle_mouse_button_event(MouseButton button, bool pressed);
         void handle_mouse_motion_event(float x, float y);
+
+        void on_keybind_changed(const std::string& configKey, std::string enumString);
 
     private:
         struct ActionBinding

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,6 +20,7 @@ xkbcommon = dependency('xkbcommon')
 xcb = dependency('xcb', required: false)
 x11 = dependency('x11')
 
+subdir('platform')
 subdir('config')
 subdir('gui')
 subdir('input')

--- a/src/platform/file_watcher.cpp
+++ b/src/platform/file_watcher.cpp
@@ -1,0 +1,22 @@
+#include "file_watcher.hpp"
+
+#if defined(__linux__)
+    #include "linux/file_watcher.hpp"
+    using FileWatcherImpl = vkShade::Platform::LinuxFileWatcher;
+#else
+    #error "Unsupported platform"
+#endif
+
+namespace vkShade::Platform
+{
+    std::unique_ptr<FileWatcher> FileWatcher::create()
+    {
+        try {
+            return std::make_unique<FileWatcherImpl>();
+        }
+        catch (const std::system_error& e) {
+            Logger::error("Failed to create file watcher: {}", e.what());
+            return nullptr;
+        }
+    }
+} // namespace vkShade::Platform

--- a/src/platform/file_watcher.hpp
+++ b/src/platform/file_watcher.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <filesystem>
+
+namespace vkShade::Platform
+{
+    class FileWatcher
+    {
+    public:
+        virtual ~FileWatcher() = default;
+
+        virtual bool watch(const std::filesystem::path& path) = 0;
+        virtual bool changed() = 0;
+
+        static std::unique_ptr<FileWatcher> create();
+    };
+} // namespace vkShade::Platform

--- a/src/platform/linux/file_watcher.hpp
+++ b/src/platform/linux/file_watcher.hpp
@@ -1,0 +1,121 @@
+#include "platform/file_watcher.hpp"
+
+#include <cstring>
+#include <sys/inotify.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "core/logger.hpp"
+
+namespace vkShade::Platform
+{
+    class LinuxFileWatcher final : public FileWatcher
+    {
+    public:
+        LinuxFileWatcher()
+        {
+            m_fd = inotify_init1(IN_NONBLOCK);
+            if (m_fd < 0)
+                throw std::system_error(errno, std::generic_category(), "inotify_init1");
+        }
+
+        ~LinuxFileWatcher() override
+        {
+            if (m_fd >= 0)
+                close(m_fd);
+        }
+
+        bool watch(const std::filesystem::path& path) override
+        {
+            // Remove any existing watch first
+            if (m_watchDescriptor >= 0)
+            {
+                inotify_rm_watch(m_fd, m_watchDescriptor);
+                m_watchDescriptor = -1;
+            }
+
+            std::filesystem::path absolutePath = std::filesystem::absolute(path);
+
+            m_directory = absolutePath.parent_path();
+            m_filename = absolutePath.filename();
+
+            m_watchDescriptor = inotify_add_watch(m_fd, m_directory.c_str(),
+                IN_CLOSE_WRITE | IN_MOVED_TO | IN_CREATE | IN_DELETE | IN_DELETE_SELF);
+
+            return m_watchDescriptor >= 0;
+        }
+
+        bool changed() override
+        {
+            if (m_fd < 0 || m_watchDescriptor < 0)
+                return false;
+
+            // The buffer used for reading from the inotify file descriptor
+            //  should have the same alignment as struct inotify_event.
+            alignas(inotify_event) char buffer[4096];
+
+            bool changed = false;
+            while (true)
+            {
+                ssize_t bytesRead = read(m_fd, buffer, sizeof(buffer));
+
+                if (bytesRead < 0)
+                {
+                    if (errno == EINTR)
+                        continue;   // Interrupted by a signal. Retry the read.
+                    if (errno == EAGAIN)
+                        break;      // Non-blocking fd has no more events to read.
+
+                    // Any other error means the inotify fd can no longer be used.
+                    Logger::error("inotify read failed: {}", std::strerror(errno));
+                    close(m_fd);
+                    m_fd = -1;
+                    m_watchDescriptor = -1;
+                    break;
+                }
+
+                if (bytesRead == 0)
+                    break;
+
+                size_t offset = 0;
+                while (offset < static_cast<size_t>(bytesRead))
+                {
+                    const auto* event = reinterpret_cast<const inotify_event*>(buffer + offset);
+
+                    if (event->wd == m_watchDescriptor)
+                    {
+                        if (event->mask & IN_IGNORED)
+                        {
+                            // The watch was invalidated, e.g. because the watched
+                            //  directory was deleted or unmounted.
+                            Logger::error("inotify watch invalidated: {}", m_directory.string());
+                            m_watchDescriptor = -1;
+                            changed = false;
+                        }
+                        else if (event->len > 0 && m_filename == event->name)
+                        {
+                            // Treat writes, atomic replacements, creation, and deletion as changes.
+                            // Editors commonly replace files by renaming a temporary file over them.
+                            if (event->mask & (IN_CLOSE_WRITE | IN_MOVED_TO | IN_CREATE | IN_DELETE))
+                            {
+                                Logger::debug("File change detected: {}", m_filename.string());
+                                changed = true;
+                            }
+                        }
+                    }
+
+                    offset += sizeof(inotify_event) + event->len;
+                }
+            }
+
+            return changed;
+        }
+
+    private:
+        int m_fd {-1};
+        int m_watchDescriptor {-1};
+
+        std::filesystem::path m_directory;
+        std::filesystem::path m_filename;
+    };
+} // namespace vkShade::Platform

--- a/src/platform/meson.build
+++ b/src/platform/meson.build
@@ -1,0 +1,16 @@
+libplatform_source = [
+  'file_watcher.cpp',
+]
+
+libplatform_library = static_library(
+  'platform',
+  libplatform_source,
+  dependencies : [
+    spdlog,
+  ],
+  include_directories : vkShade_include_path
+)
+
+libplatform = declare_dependency(
+  link_with : libplatform_library,
+)

--- a/tests/config_observer_tests.cpp
+++ b/tests/config_observer_tests.cpp
@@ -1,4 +1,5 @@
 #include "config/config_observer.hpp"
+#include "config/config_store.hpp"
 
 #include <string>
 #include <vector>
@@ -326,46 +327,4 @@ TEST_CASE("ConfigObserver: Reconnect after disconnect", "[config][observer]")
     REQUIRE(g_callbackLog.size() == 2);
     REQUIRE(g_callbackLog[0] == "string:first");
     REQUIRE(g_callbackLog[1] == "string:third");
-}
-
-TEST_CASE("ConfigObserver: notify_all_defaults() calls free function with default value", "[config][observer]")
-{
-    g_callbackLog.clear();
-    ConfigObserver observer;
-
-    observer.on_changed("test", "value").connect<&on_string_changed>();
-    observer.notify_all_defaults();
-
-    REQUIRE(g_callbackLog.size() == 1);
-    REQUIRE(g_callbackLog[0] == "string:");  // empty string default
-}
-
-TEST_CASE("ConfigObserver: notify_all_defaults() calls member function with default value", "[config][observer]")
-{
-    TestListener listener;
-    ConfigObserver observer;
-
-    observer.on_changed("test", "value").connect<&TestListener::on_float_value>(&listener);
-    observer.notify_all_defaults();
-
-    REQUIRE(listener.get_call_count() == 1);
-    REQUIRE(listener.get_last_float() == 0.0f);
-}
-
-TEST_CASE("ConfigObserver: notify_all_defaults() calls all keys", "[config][observer]")
-{
-    g_callbackLog.clear();
-    ConfigObserver observer;
-
-    observer.on_changed("test", "string").connect<&on_string_changed>();
-    observer.on_changed("test", "float").connect<&on_float_changed>();
-    observer.notify_all_defaults();
-
-    REQUIRE(g_callbackLog.size() == 2);
-}
-
-TEST_CASE("ConfigObserver: notify_all_defaults() with no subscribers does nothing", "[config][observer]")
-{
-    ConfigObserver observer;
-    REQUIRE_NOTHROW(observer.notify_all_defaults());
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,7 @@
 catch2 = dependency('catch2-with-main', version : '>=3.0.0')
 
+subdir('platform')
+
 config_observer_tests = executable('config_observer_tests',
   'config_observer_tests.cpp',
   dependencies : [

--- a/tests/platform/linux/file_watcher_tests.cpp
+++ b/tests/platform/linux/file_watcher_tests.cpp
@@ -1,0 +1,172 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <fstream>
+
+#include "platform/linux/file_watcher.hpp"
+
+using namespace vkShade::Platform;
+namespace fs = std::filesystem;
+
+namespace
+{
+    // Unique temp dir per test case so tests can't interfere with each other.
+    fs::path make_temp_dir(const std::string& name)
+    {
+        fs::path dir = fs::temp_directory_path() / ("vkshade_fw_test_" + name);
+        fs::remove_all(dir);
+        fs::create_directories(dir);
+        return dir;
+    }
+
+    void write_file(const fs::path& path, const std::string& content = "x")
+    {
+        std::ofstream f(path, std::ios::trunc);
+        f << content;
+    }
+}
+
+TEST_CASE("LinuxFileWatcher: watch() succeeds on a valid existing file", "[platform][filewatcher]")
+{
+    fs::path dir = make_temp_dir("valid");
+    fs::path file = dir / "config.ini";
+    write_file(file);
+
+    LinuxFileWatcher watcher;
+    REQUIRE(watcher.watch(file));
+}
+
+TEST_CASE("LinuxFileWatcher: watch() fails when the directory doesn't exist", "[platform][filewatcher]")
+{
+    fs::path missing = fs::temp_directory_path() / "vkshade_fw_test_does_not_exist" / "config.ini";
+
+    LinuxFileWatcher watcher;
+    REQUIRE_FALSE(watcher.watch(missing));
+}
+
+TEST_CASE("LinuxFileWatcher: changed() is false with nothing touched", "[platform][filewatcher]")
+{
+    fs::path dir = make_temp_dir("idle");
+    fs::path file = dir / "config.ini";
+    write_file(file);
+
+    LinuxFileWatcher watcher;
+    REQUIRE(watcher.watch(file));
+
+    REQUIRE_FALSE(watcher.changed());
+}
+
+TEST_CASE("LinuxFileWatcher: Writing to the watched file triggers changed()", "[platform][filewatcher]")
+{
+    fs::path dir = make_temp_dir("write");
+    fs::path file = dir / "config.ini";
+    write_file(file);
+
+    LinuxFileWatcher watcher;
+    REQUIRE(watcher.watch(file));
+
+    write_file(file, "y");
+
+    REQUIRE(watcher.changed());
+}
+
+TEST_CASE("LinuxFileWatcher: Only the watched filename triggers changed()", "[platform][filewatcher]")
+{
+    fs::path dir = make_temp_dir("filter");
+    fs::path watched = dir / "config.ini";
+    fs::path other = dir / "unrelated.ini";
+    write_file(watched);
+    write_file(other);
+
+    LinuxFileWatcher watcher;
+    REQUIRE(watcher.watch(watched));
+
+    write_file(other, "changed");
+
+    // Sibling file in the same watched directory must NOT count as a change.
+    REQUIRE_FALSE(watcher.changed());
+
+    // Positive control: Prove the watcher is actually alive and working,
+    //  not just silently dead (which would also make the above pass).
+    write_file(watched, "changed");
+    REQUIRE(watcher.changed());
+}
+
+TEST_CASE("LinuxFileWatcher: Re-watching a new file stops watching the old one", "[platform][filewatcher]")
+{
+    fs::path dirA = make_temp_dir("rewatch_a");
+    fs::path dirB = make_temp_dir("rewatch_b");
+    fs::path fileA = dirA / "config.ini";
+    fs::path fileB = dirB / "config.ini";
+    write_file(fileA);
+    write_file(fileB);
+
+    LinuxFileWatcher watcher;
+    REQUIRE(watcher.watch(fileA));
+    REQUIRE(watcher.watch(fileB));  // Should replace, not add to, the fileA watch
+
+    write_file(fileA, "changed");   // Old watch target — must be silently ignored now
+
+    REQUIRE_FALSE(watcher.changed());
+
+    // Positive control: Prove the watcher is actually alive and working,
+    //  not just silently dead (which would also make the above pass).
+    write_file(fileB, "changed");
+    REQUIRE(watcher.changed());
+}
+
+TEST_CASE("LinuxFileWatcher: Re-watching a new file still detects changes to it", "[platform][filewatcher]")
+{
+    fs::path dirA = make_temp_dir("rewatch_still_works_a");
+    fs::path dirB = make_temp_dir("rewatch_still_works_b");
+    fs::path fileA = dirA / "config.ini";
+    fs::path fileB = dirB / "config.ini";
+    write_file(fileA);
+    write_file(fileB);
+
+    LinuxFileWatcher watcher;
+    REQUIRE(watcher.watch(fileA));
+    REQUIRE(watcher.watch(fileB));
+
+    write_file(fileB, "changed");
+
+    REQUIRE(watcher.changed());
+}
+
+TEST_CASE("LinuxFileWatcher: Deleting the watched directory does not report changed()", "[platform][filewatcher]")
+{
+    fs::path dir = make_temp_dir("delete_self");
+    fs::path file = dir / "config.ini";
+    write_file(file);
+
+    LinuxFileWatcher watcher;
+    REQUIRE(watcher.watch(file));
+
+    fs::remove_all(dir);
+
+    // Per the current design, IN_IGNORED (watch invalidated) is swallowed
+    // and reported as changed == false, not true — this locks that behavior
+    // in as a regression test.
+    REQUIRE_FALSE(watcher.changed());
+}
+
+TEST_CASE("LinuxFileWatcher: Can re-watch after the underlying directory was deleted", "[platform][filewatcher]")
+{
+    fs::path dir = make_temp_dir("recover");
+    fs::path file = dir / "config.ini";
+    write_file(file);
+
+    LinuxFileWatcher watcher;
+    REQUIRE(watcher.watch(file));
+
+    fs::remove_all(dir);
+    (void)watcher.changed(); // Drain/process the IN_IGNORED event
+
+    // Recreate and re-watch — confirms m_watchDescriptor was properly reset
+    // to -1 and watch() can recover rather than staying wedged.
+    fs::create_directories(dir);
+    write_file(file);
+    REQUIRE(watcher.watch(file));
+
+    write_file(file, "changed");
+    REQUIRE(watcher.changed());
+}

--- a/tests/platform/linux/meson.build
+++ b/tests/platform/linux/meson.build
@@ -1,0 +1,10 @@
+linux_filewatcher_tests = executable('linux_filewatcher_tests',
+  'file_watcher_tests.cpp',
+  dependencies : [
+    catch2,
+    spdlog,
+  ],
+  include_directories : vkShade_include_path
+)
+
+test('LinuxFileWatcher', linux_filewatcher_tests)

--- a/tests/platform/meson.build
+++ b/tests/platform/meson.build
@@ -1,0 +1,3 @@
+if host_machine.system() == 'linux'
+  subdir('linux')
+endif


### PR DESCRIPTION
Adds the infrastructure needed to reload configuration and preset files when they change.

## Changes

- Simplify config observer subscriptions and notification handling
- Add a platform-independent `FileWatcher` abstraction
- Implement Linux file watching using inotify
- Add automated tests for the Linux file watcher.
- Watch the vkShade config and ReShade preset files for changes
- Automatically reload files when changes are detected

The platform abstraction keeps OS-specific file watching behavior isolated, allowing additional platform implementations in the future.

## Testing

- Manually tested config and preset hot-reloading with `vkcube`.
- Every commit compiles, runs, and passes tests.