### PR TITLE
fix(config): recreate FileWatcher when loading a config file

### DIFF
--- a/src/config/config_manager.cpp
+++ b/src/config/config_manager.cpp
@@ -45,8 +45,6 @@ void vkShade::ConfigManager::load_config_file()
         if (m_config.load(filePath))
         {
             // Successfully loaded candidate
-            m_configWatcher = Platform::FileWatcher::create();
-            m_configWatcher->watch(filePath);
             return;
         }
     }
@@ -85,8 +83,6 @@ void vkShade::ConfigManager::load_preset_file()
         if (m_preset.load(filePath))
         {
             // Successfully loaded candidate
-            m_presetWatcher = Platform::FileWatcher::create();
-            m_presetWatcher->watch(filePath);
             return;
         }
     }
@@ -96,17 +92,6 @@ void vkShade::ConfigManager::load_preset_file()
 
 void vkShade::ConfigManager::update()
 {
-    if (m_configWatcher && m_configWatcher->changed())
-    {
-        auto filePath = m_config.get_path();
-        if (!filePath.empty())
-            m_config.load(filePath);
-    }
-
-    if (m_presetWatcher && m_presetWatcher->changed())
-    {
-        auto filePath = m_preset.get_path();
-        if (!filePath.empty())
-            m_preset.load(filePath);
-    }
+    m_config.update();
+    m_preset.update();
 }

--- a/src/config/config_manager.hpp
+++ b/src/config/config_manager.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "config_store.hpp"
-#include "platform/file_watcher.hpp"
 
 namespace vkShade
 {
@@ -20,9 +19,6 @@ namespace vkShade
         ConfigStore m_config;
         ConfigStore m_internal;
         ConfigStore m_preset;
-
-        std::unique_ptr<Platform::FileWatcher> m_configWatcher;
-        std::unique_ptr<Platform::FileWatcher> m_presetWatcher;
 
         void load_config_file();
         void load_preset_file();

--- a/src/config/config_store.cpp
+++ b/src/config/config_store.cpp
@@ -49,6 +49,7 @@ bool vkShade::ConfigStore::load(std::filesystem::path filePath)
         return false;
 
     // Clear existing state if there is any
+    m_watcher.reset();
     this->clear();
 
     // Parse the INI file
@@ -60,6 +61,9 @@ bool vkShade::ConfigStore::load(std::filesystem::path filePath)
     }
 
     m_observer.notify_all(*this);
+
+    m_watcher = Platform::FileWatcher::create();
+    m_watcher->watch(filePath);
 
     Logger::info("Loaded {} file: {}", m_typeString, filePath.string());
 

--- a/src/config/config_store.hpp
+++ b/src/config/config_store.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "platform/file_watcher.hpp"
 #include "config_observer.hpp"
 #include "config_parser.hpp"
 #include "config_types.hpp"
@@ -81,6 +82,12 @@ namespace vkShade
             return m_observer.on_changed(section, key);
         }
 
+        void update()
+        {
+            if (m_watcher && m_watcher->changed())
+                this->load(m_currentFile);
+        }
+
     private:
         Type m_type;
         std::string m_typeString;
@@ -90,6 +97,8 @@ namespace vkShade
 
         std::filesystem::path m_currentFile;
         std::unordered_map<std::string, std::string> m_config;
+
+        std::unique_ptr<Platform::FileWatcher> m_watcher;
     };
 } // namespace vkShade
 


### PR DESCRIPTION
## Summary

Fixes an issue where loading a different config file didn't update the watcher.

## Changes

- Move FileWatcher ownership to ConfigStore
- Recreate the watcher when loading a new file

## Testing

Manual testing procedure:

1. Run vkShade with the default preset: `~/.local/share/vkShade/ReShade.ini`
2. Confirm file watcher is working by changing the preset.
3. Copy preset file to the CWD.
4. Choose **File >> Load** in the GUI, which currently loads preset from the CWD.
5. Attempt to trigger old file watch - failed as expected.
6. Attempt to trigger new file watch - succeeded.