### PR TITLE
build(deps): suppress warnings from third-party code

### DIFF
--- a/subprojects/packagefiles/reshadefx/meson.build
+++ b/subprojects/packagefiles/reshadefx/meson.build
@@ -18,7 +18,7 @@ reshadefx_sources = files(
   'source/effect_symbol_table.cpp',
 )
 
-reshadefx_inc = include_directories('source')
+reshadefx_inc = include_directories('source', is_system: true)
 
 spirv_headers_dep = subproject('spirv-headers').get_variable('spirv_headers_dep')
 
@@ -26,7 +26,7 @@ reshadefx_lib = static_library('reshadefx',
   reshadefx_sources,
   dependencies : spirv_headers_dep,
   include_directories : reshadefx_inc,
-  cpp_args : ['-DNDEBUG'],
+  cpp_args : ['-DNDEBUG', '-w'],
   install : false,
 )
 

--- a/subprojects/packagefiles/vulkan-memory-allocator/LICENSE.build
+++ b/subprojects/packagefiles/vulkan-memory-allocator/LICENSE.build
@@ -1,0 +1,19 @@
+Copyright (c) 2021 The Meson development team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/subprojects/packagefiles/vulkan-memory-allocator/meson.build
+++ b/subprojects/packagefiles/vulkan-memory-allocator/meson.build
@@ -1,0 +1,9 @@
+project('VulkanMemoryAllocator', ['c', 'cpp'], version: '3.1.0')
+
+vma_allocator_dep = declare_dependency(
+    include_directories: include_directories('include', is_system: true)
+)
+
+if get_option('build_samples')
+    subdir('src')
+endif

--- a/subprojects/packagefiles/vulkan-memory-allocator/meson_options.txt
+++ b/subprojects/packagefiles/vulkan-memory-allocator/meson_options.txt
@@ -1,0 +1,1 @@
+option('build_samples', type: 'boolean', value: false)

--- a/subprojects/vulkan-memory-allocator.wrap
+++ b/subprojects/vulkan-memory-allocator.wrap
@@ -3,11 +3,8 @@ directory = VulkanMemoryAllocator-3.1.0
 source_url = https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/refs/tags/v3.1.0.tar.gz
 source_filename = VulkanMemoryAllocator-3.1.0.tar.gz
 source_hash = ae134ecc37c55634f108e926f85d5d887b670360e77cd107affaf3a9539595f2
-patch_filename = vulkan-memory-allocator_3.1.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/vulkan-memory-allocator_3.1.0-1/get_patch
-patch_hash = d62a983856146f4529c5c5a46b13c0451a4f7e02d0966606dcd054a204c5fd80
+patch_directory = vulkan-memory-allocator
 source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/vulkan-memory-allocator_3.1.0-1/VulkanMemoryAllocator-3.1.0.tar.gz
-wrapdb_version = 3.1.0-1
 
 [provide]
 vulkan-memory-allocator = vma_allocator_dep


### PR DESCRIPTION
These are just noise that make it harder to identify issues in vkShade code.