### PR TITLE
fix(hooks): initialize EventBus at instance creation time

### DIFF
--- a/src/core/event_bus.hpp
+++ b/src/core/event_bus.hpp
@@ -24,7 +24,7 @@ namespace vkShade
         class Sink
         {
         public:
-            Sink(EventBus& bus) : m_bus(bus) {}
+            explicit Sink(EventBus& bus) : m_bus(bus) {}
 
             // Connect a free function
             template<void (*Func)(const EventType&)>
@@ -209,6 +209,5 @@ namespace vkShade
                 );
             }
         }
-
     };
 } // namespace vkShade

--- a/src/hooks/hooks_device.cpp
+++ b/src/hooks/hooks_device.cpp
@@ -8,14 +8,9 @@
 
 #include <vulkan/vk_layer.h>
 
-#include "config/config_manager.hpp"
-#include "core/event_bus.hpp"
 #include "core/logger.hpp"
 #include "core/service_locator.hpp"
-#include "core/resource_cache.hpp"
 #include "gui/gui_manager.hpp"
-#include "vk/reshade_effect.hpp"
-#include "vk/shader_module.hpp"
 
 VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
     VkPhysicalDevice                            physicalDevice,
@@ -203,10 +198,6 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateDevice(
         std::unique_lock lock(g_globalLock);
         g_vulkanDevices.emplace(dispatch_key_from_handle(*pDevice), thisDevice);
     }
-
-    // Initialize vkShade subsystems here
-    vkShade::Locator<vkShade::EventBus>::emplace();
-    vkShade::Locator<vkShade::ResourceCache<vkShade::ShaderModule>>::emplace();
 
     vkShade::Logger::info("Layer initialization complete");
     return VK_SUCCESS;

--- a/src/hooks/hooks_instance.cpp
+++ b/src/hooks/hooks_instance.cpp
@@ -3,7 +3,11 @@
 #include <magic_enum/magic_enum.hpp>
 #include <vulkan/vk_layer.h>
 
+#include "core/event_bus.hpp"
 #include "core/logger.hpp"
+#include "core/resource_cache.hpp"
+#include "core/service_locator.hpp"
+#include "vk/shader_module.hpp"
 
 VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,
@@ -72,6 +76,9 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkShade_CreateInstance(
         // Acquire a writer lock
         std::unique_lock lock(g_globalLock);
         g_vulkanInstances.emplace(dispatch_key_from_handle(*pInstance), thisInstance);
+
+        // Initialize instance-level subsystems
+        vkShade::Locator<vkShade::EventBus>::emplace();
     }
 
     return VK_SUCCESS;


### PR DESCRIPTION
Also marks the EventBus Sink constructor `explicit` to resolve a linter error that surfaced.