### PR TITLE
feat(input): finish integrating keyboard and mouse events

### DIFF
--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -7,7 +7,7 @@
 #include "core/service_locator.hpp"
 #include "core/logger.hpp"
 #include "hooks/hooks.hpp"
-#include "input/input_manager.hpp"
+#include "input/input_events.hpp"
 #include "windows/main_window.hpp"
 #include "vk/macros.hpp"
 #include "gui_style.hpp"
@@ -99,6 +99,11 @@ vkShade::GuiManager::GuiManager(VulkanDevice deviceContext, VkFormat swapchainFo
 
     // Apply custom style
     UIStyle::ApplyStyle();
+
+    // Subscribe to input events
+    auto& eventBus = Locator<EventBus>::get();
+    eventBus.sink<MouseButtonEvent>().connect<&GuiManager::on_mouse_button_event>(this);
+    eventBus.sink<MouseMotionEvent>().connect<&GuiManager::on_mouse_motion_event>(this);
 }
 
 vkShade::GuiManager::~GuiManager()
@@ -119,19 +124,21 @@ void vkShade::GuiManager::draw_cursor()
     drawList->AddCircleFilled(pos, 1.5f, IM_COL32(255, 0, 0, 255));
 }
 
+void vkShade::GuiManager::on_mouse_button_event(const MouseButtonEvent& event)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    io.AddMouseButtonEvent(static_cast<int32_t>(event.button), event.pressed);
+}
+
+void vkShade::GuiManager::on_mouse_motion_event(const MouseMotionEvent& event)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    io.AddMousePosEvent(event.x, event.y);
+}
+
 void vkShade::GuiManager::update(float deltaTime, VkExtent2D swapchainExtent)
 {
-    auto& input = vkShade::Locator<InputManager>::get();
-
     ImGuiIO& io = ImGui::GetIO();
-
-    // Update mouse state
-    glm::vec2 mousePos = input.mouse_position();
-    io.AddMousePosEvent(mousePos.x, mousePos.y);
-    io.AddMouseButtonEvent(0, input.is_mouse_button_pressed(MouseButton::LEFT));
-    io.AddMouseButtonEvent(1, input.is_mouse_button_pressed(MouseButton::RIGHT));
-    io.AddMouseButtonEvent(2, input.is_mouse_button_pressed(MouseButton::MIDDLE));
-
     io.DisplaySize = ImVec2((float)swapchainExtent.width, (float)swapchainExtent.height);
     io.DeltaTime = deltaTime;
 

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -11,6 +11,7 @@
 #include "windows/main_window.hpp"
 #include "vk/macros.hpp"
 #include "gui_style.hpp"
+#include "input_helpers.hpp"
 
 vkShade::GuiManager::GuiManager(VulkanDevice deviceContext, VkFormat swapchainFormat)
 {
@@ -102,6 +103,8 @@ vkShade::GuiManager::GuiManager(VulkanDevice deviceContext, VkFormat swapchainFo
 
     // Subscribe to input events
     auto& eventBus = Locator<EventBus>::get();
+    eventBus.sink<KeyboardEvent>().connect<&GuiManager::on_keyboard_event>(this);
+    eventBus.sink<TextInputEvent>().connect<&GuiManager::on_text_input_event>(this);
     eventBus.sink<MouseButtonEvent>().connect<&GuiManager::on_mouse_button_event>(this);
     eventBus.sink<MouseMotionEvent>().connect<&GuiManager::on_mouse_motion_event>(this);
 }
@@ -124,16 +127,24 @@ void vkShade::GuiManager::draw_cursor()
     drawList->AddCircleFilled(pos, 1.5f, IM_COL32(255, 0, 0, 255));
 }
 
+void vkShade::GuiManager::on_keyboard_event(const KeyboardEvent& event)
+{
+    ImGui::GetIO().AddKeyEvent(to_imgui_key(event.keyCode), event.pressed);
+}
+
 void vkShade::GuiManager::on_mouse_button_event(const MouseButtonEvent& event)
 {
-    ImGuiIO& io = ImGui::GetIO();
-    io.AddMouseButtonEvent(static_cast<int32_t>(event.button), event.pressed);
+    ImGui::GetIO().AddMouseButtonEvent(static_cast<int32_t>(event.button), event.pressed);
 }
 
 void vkShade::GuiManager::on_mouse_motion_event(const MouseMotionEvent& event)
 {
-    ImGuiIO& io = ImGui::GetIO();
-    io.AddMousePosEvent(event.x, event.y);
+    ImGui::GetIO().AddMousePosEvent(event.x, event.y);
+}
+
+void vkShade::GuiManager::on_text_input_event(const TextInputEvent& event)
+{
+    ImGui::GetIO().AddInputCharactersUTF8(event.text.c_str());
 }
 
 void vkShade::GuiManager::update(float deltaTime, VkExtent2D swapchainExtent)

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -107,6 +107,7 @@ vkShade::GuiManager::GuiManager(VulkanDevice deviceContext, VkFormat swapchainFo
     eventBus.sink<TextInputEvent>().connect<&GuiManager::on_text_input_event>(this);
     eventBus.sink<MouseButtonEvent>().connect<&GuiManager::on_mouse_button_event>(this);
     eventBus.sink<MouseMotionEvent>().connect<&GuiManager::on_mouse_motion_event>(this);
+    eventBus.sink<MouseWheelEvent>().connect<&GuiManager::on_mouse_wheel_event>(this);
 }
 
 vkShade::GuiManager::~GuiManager()
@@ -140,6 +141,11 @@ void vkShade::GuiManager::on_mouse_button_event(const MouseButtonEvent& event)
 void vkShade::GuiManager::on_mouse_motion_event(const MouseMotionEvent& event)
 {
     ImGui::GetIO().AddMousePosEvent(event.x, event.y);
+}
+
+void vkShade::GuiManager::on_mouse_wheel_event(const MouseWheelEvent& event)
+{
+    ImGui::GetIO().AddMouseWheelEvent(event.x, event.y);
 }
 
 void vkShade::GuiManager::on_text_input_event(const TextInputEvent& event)

--- a/src/gui/gui_manager.hpp
+++ b/src/gui/gui_manager.hpp
@@ -7,8 +7,10 @@
 
 namespace vkShade
 {
+    struct KeyboardEvent;
     struct MouseButtonEvent;
     struct MouseMotionEvent;
+    struct TextInputEvent;
 
     class GuiManager
     {
@@ -30,7 +32,9 @@ namespace vkShade
 
         void draw_cursor();
 
+        void on_keyboard_event(const KeyboardEvent& event);
         void on_mouse_button_event(const MouseButtonEvent& event);
         void on_mouse_motion_event(const MouseMotionEvent& event);
+        void on_text_input_event(const TextInputEvent& event);
     };
 } // namespace vkShade

--- a/src/gui/gui_manager.hpp
+++ b/src/gui/gui_manager.hpp
@@ -10,6 +10,7 @@ namespace vkShade
     struct KeyboardEvent;
     struct MouseButtonEvent;
     struct MouseMotionEvent;
+    struct MouseWheelEvent;
     struct TextInputEvent;
 
     class GuiManager
@@ -35,6 +36,7 @@ namespace vkShade
         void on_keyboard_event(const KeyboardEvent& event);
         void on_mouse_button_event(const MouseButtonEvent& event);
         void on_mouse_motion_event(const MouseMotionEvent& event);
+        void on_mouse_wheel_event(const MouseWheelEvent& event);
         void on_text_input_event(const TextInputEvent& event);
     };
 } // namespace vkShade

--- a/src/gui/gui_manager.hpp
+++ b/src/gui/gui_manager.hpp
@@ -7,6 +7,9 @@
 
 namespace vkShade
 {
+    struct MouseButtonEvent;
+    struct MouseMotionEvent;
+
     class GuiManager
     {
     public:
@@ -26,5 +29,8 @@ namespace vkShade
         MainWindow m_mainWindow;
 
         void draw_cursor();
+
+        void on_mouse_button_event(const MouseButtonEvent& event);
+        void on_mouse_motion_event(const MouseMotionEvent& event);
     };
 } // namespace vkShade

--- a/src/gui/input_helpers.hpp
+++ b/src/gui/input_helpers.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <imgui.h>
+
+#include "../input/key_codes.hpp"
+
+namespace vkShade
+{
+    inline ImGuiKey to_imgui_key(KeyCode key)
+    {
+        switch (key)
+        {
+            case KeyCode::KEY_0:             return ImGuiKey_0;
+            case KeyCode::KEY_1:             return ImGuiKey_1;
+            case KeyCode::KEY_2:             return ImGuiKey_2;
+            case KeyCode::KEY_3:             return ImGuiKey_3;
+            case KeyCode::KEY_4:             return ImGuiKey_4;
+            case KeyCode::KEY_5:             return ImGuiKey_5;
+            case KeyCode::KEY_6:             return ImGuiKey_6;
+            case KeyCode::KEY_7:             return ImGuiKey_7;
+            case KeyCode::KEY_8:             return ImGuiKey_8;
+            case KeyCode::KEY_9:             return ImGuiKey_9;
+
+            case KeyCode::KEY_A:             return ImGuiKey_A;
+            case KeyCode::KEY_B:             return ImGuiKey_B;
+            case KeyCode::KEY_C:             return ImGuiKey_C;
+            case KeyCode::KEY_D:             return ImGuiKey_D;
+            case KeyCode::KEY_E:             return ImGuiKey_E;
+            case KeyCode::KEY_F:             return ImGuiKey_F;
+            case KeyCode::KEY_G:             return ImGuiKey_G;
+            case KeyCode::KEY_H:             return ImGuiKey_H;
+            case KeyCode::KEY_I:             return ImGuiKey_I;
+            case KeyCode::KEY_J:             return ImGuiKey_J;
+            case KeyCode::KEY_K:             return ImGuiKey_K;
+            case KeyCode::KEY_L:             return ImGuiKey_L;
+            case KeyCode::KEY_M:             return ImGuiKey_M;
+            case KeyCode::KEY_N:             return ImGuiKey_N;
+            case KeyCode::KEY_O:             return ImGuiKey_O;
+            case KeyCode::KEY_P:             return ImGuiKey_P;
+            case KeyCode::KEY_Q:             return ImGuiKey_Q;
+            case KeyCode::KEY_R:             return ImGuiKey_R;
+            case KeyCode::KEY_S:             return ImGuiKey_S;
+            case KeyCode::KEY_T:             return ImGuiKey_T;
+            case KeyCode::KEY_U:             return ImGuiKey_U;
+            case KeyCode::KEY_V:             return ImGuiKey_V;
+            case KeyCode::KEY_W:             return ImGuiKey_W;
+            case KeyCode::KEY_X:             return ImGuiKey_X;
+            case KeyCode::KEY_Y:             return ImGuiKey_Y;
+            case KeyCode::KEY_Z:             return ImGuiKey_Z;
+
+            case KeyCode::KEY_BACKQUOTE:     return ImGuiKey_GraveAccent;
+            case KeyCode::KEY_TAB:           return ImGuiKey_Tab;
+            case KeyCode::KEY_LSHIFT:        return ImGuiKey_LeftShift;
+            case KeyCode::KEY_RSHIFT:        return ImGuiKey_RightShift;
+            case KeyCode::KEY_LCTRL:         return ImGuiKey_LeftCtrl;
+            case KeyCode::KEY_RCTRL:         return ImGuiKey_RightCtrl;
+            case KeyCode::KEY_LALT:          return ImGuiKey_LeftAlt;
+            case KeyCode::KEY_RALT:          return ImGuiKey_RightAlt;
+            case KeyCode::KEY_SPACE:         return ImGuiKey_Space;
+            case KeyCode::KEY_ESCAPE:        return ImGuiKey_Escape;
+            case KeyCode::KEY_BACKSPACE:     return ImGuiKey_Backspace;
+            case KeyCode::KEY_RETURN:        return ImGuiKey_Enter;
+            case KeyCode::KEY_EQUALS:        return ImGuiKey_Equal;
+            case KeyCode::KEY_MINUS:         return ImGuiKey_Minus;
+            case KeyCode::KEY_LEFTBRACKET:   return ImGuiKey_LeftBracket;
+            case KeyCode::KEY_RIGHTBRACKET:  return ImGuiKey_RightBracket;
+            case KeyCode::KEY_BACKSLASH:     return ImGuiKey_Backslash;
+            case KeyCode::KEY_SEMICOLON:     return ImGuiKey_Semicolon;
+            case KeyCode::KEY_QUOTE:         return ImGuiKey_Apostrophe;
+            case KeyCode::KEY_SLASH:         return ImGuiKey_Slash;
+            case KeyCode::KEY_COMMA:         return ImGuiKey_Comma;
+            case KeyCode::KEY_PERIOD:        return ImGuiKey_Period;
+
+            case KeyCode::KEY_INSERT:        return ImGuiKey_Insert;
+            case KeyCode::KEY_DELETE:        return ImGuiKey_Delete;
+            case KeyCode::KEY_HOME:          return ImGuiKey_Home;
+            case KeyCode::KEY_END:           return ImGuiKey_End;
+            case KeyCode::KEY_PAGEUP:        return ImGuiKey_PageUp;
+            case KeyCode::KEY_PAGEDOWN:      return ImGuiKey_PageDown;
+            case KeyCode::KEY_PRINTSCREEN:   return ImGuiKey_PrintScreen;
+            case KeyCode::KEY_UP:            return ImGuiKey_UpArrow;
+            case KeyCode::KEY_DOWN:          return ImGuiKey_DownArrow;
+            case KeyCode::KEY_LEFT:          return ImGuiKey_LeftArrow;
+            case KeyCode::KEY_RIGHT:         return ImGuiKey_RightArrow;
+
+            case KeyCode::KEY_NUMPAD_PLUS:   return ImGuiKey_KeypadAdd;
+            case KeyCode::KEY_NUMPAD_MINUS:  return ImGuiKey_KeypadSubtract;
+            case KeyCode::KEY_NUMPAD_MULTIPLY:return ImGuiKey_KeypadMultiply;
+            case KeyCode::KEY_NUMPAD_DIVIDE: return ImGuiKey_KeypadDivide;
+            case KeyCode::KEY_NUMPAD_PERIOD: return ImGuiKey_KeypadDecimal;
+            case KeyCode::KEY_NUMPAD_ENTER:  return ImGuiKey_KeypadEnter;
+            case KeyCode::KEY_NUMPAD_0:      return ImGuiKey_Keypad0;
+            case KeyCode::KEY_NUMPAD_1:      return ImGuiKey_Keypad1;
+            case KeyCode::KEY_NUMPAD_2:      return ImGuiKey_Keypad2;
+            case KeyCode::KEY_NUMPAD_3:      return ImGuiKey_Keypad3;
+            case KeyCode::KEY_NUMPAD_4:      return ImGuiKey_Keypad4;
+            case KeyCode::KEY_NUMPAD_5:      return ImGuiKey_Keypad5;
+            case KeyCode::KEY_NUMPAD_6:      return ImGuiKey_Keypad6;
+            case KeyCode::KEY_NUMPAD_7:      return ImGuiKey_Keypad7;
+            case KeyCode::KEY_NUMPAD_8:      return ImGuiKey_Keypad8;
+            case KeyCode::KEY_NUMPAD_9:      return ImGuiKey_Keypad9;
+
+            case KeyCode::KEY_F1:            return ImGuiKey_F1;
+            case KeyCode::KEY_F2:            return ImGuiKey_F2;
+            case KeyCode::KEY_F3:            return ImGuiKey_F3;
+            case KeyCode::KEY_F4:            return ImGuiKey_F4;
+            case KeyCode::KEY_F5:            return ImGuiKey_F5;
+            case KeyCode::KEY_F6:            return ImGuiKey_F6;
+            case KeyCode::KEY_F7:            return ImGuiKey_F7;
+            case KeyCode::KEY_F8:            return ImGuiKey_F8;
+            case KeyCode::KEY_F9:            return ImGuiKey_F9;
+            case KeyCode::KEY_F10:           return ImGuiKey_F10;
+            case KeyCode::KEY_F11:           return ImGuiKey_F11;
+            case KeyCode::KEY_F12:           return ImGuiKey_F12;
+
+            default:                         return ImGuiKey_None;
+        }
+    }
+}

--- a/src/input/input_backend_wayland.cpp
+++ b/src/input/input_backend_wayland.cpp
@@ -21,11 +21,10 @@ vkShade::InputBackendWayland::InputBackendWayland(wl_display* waylandDisplay)
 
 void vkShade::InputBackendWayland::on_keyboard_key(uint32_t key, uint32_t state)
 {
-    uint32_t keycode = key + 8;  // Wayland uses evdev codes, XKB expects +8
-    xkb_keysym_t sym = xkb_state_key_get_one_sym(m_xkbState, keycode);
+    uint32_t keyCode = key + 8;  // Wayland uses evdev codes, XKB expects +8
     bool pressed = (state == WL_KEYBOARD_KEY_STATE_PRESSED);
 
-    handle_keyboard_event(sym, pressed);
+    handle_keyboard_event(keyCode, pressed);
 }
 
 void vkShade::InputBackendWayland::on_keyboard_keymap(uint32_t format, int32_t fd, uint32_t size)

--- a/src/input/input_backend_wayland.cpp
+++ b/src/input/input_backend_wayland.cpp
@@ -95,16 +95,28 @@ void vkShade::InputBackendWayland::on_pointer_button(uint32_t serial, uint32_t t
 
 void vkShade::InputBackendWayland::on_pointer_axis(uint32_t time, uint32_t axis, wl_fixed_t value)
 {
-    // Handle scroll wheel
-    float scroll = wl_fixed_to_double(value);
-    Logger::trace("Scroll axis {} value {}", axis, scroll);
+}
+
+void vkShade::InputBackendWayland::on_pointer_axis_discrete(uint32_t axis, int32_t discrete)
+{
+    switch (axis)
+    {
+        case WL_POINTER_AXIS_VERTICAL_SCROLL:
+            handle_mouse_wheel_event(0.0f, -static_cast<float>(discrete));
+            break;
+
+        case WL_POINTER_AXIS_HORIZONTAL_SCROLL:
+            handle_mouse_wheel_event(-static_cast<float>(discrete), 0.0f);
+            break;
+    }
 }
 
 void vkShade::InputBackendWayland::on_registry_global(wl_registry* reg, uint32_t name, const char* interface, uint32_t version)
 {
     if (strcmp(interface, wl_seat_interface.name) == 0)
     {
-        wl_seat* seat = static_cast<wl_seat*>(wl_registry_bind(reg, name, &wl_seat_interface, 1));
+        uint32_t seatVersion = std::min(version, 5u);
+        wl_seat* seat = static_cast<wl_seat*>(wl_registry_bind(reg, name, &wl_seat_interface, seatVersion));
         wl_seat_add_listener(seat, &seat_listener, this);   // Pass 'this' as data* in callbacks
         Logger::trace("Bound to wl_seat");
     }

--- a/src/input/input_backend_wayland.hpp
+++ b/src/input/input_backend_wayland.hpp
@@ -26,6 +26,7 @@ namespace vkShade
         void on_pointer_motion(uint32_t time, wl_fixed_t x, wl_fixed_t y);
         void on_pointer_button(uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
         void on_pointer_axis(uint32_t time, uint32_t axis, wl_fixed_t value);
+        void on_pointer_axis_discrete(uint32_t axis, int32_t discrete);
 
         void process_events() override;
 

--- a/src/input/input_backend_xcb.cpp
+++ b/src/input/input_backend_xcb.cpp
@@ -98,9 +98,6 @@ void vkShade::InputBackendXcb::handle_key_event(uint32_t keyCode, bool pressed)
     if (!m_xkbState)
         return;
 
-    // Get keysym from XKB
-    xkb_keysym_t keysym = xkb_state_key_get_one_sym(m_xkbState, keyCode);
-
     // Update XKB state
     if (pressed)
         xkb_state_update_key(m_xkbState, keyCode, XKB_KEY_DOWN);
@@ -108,7 +105,7 @@ void vkShade::InputBackendXcb::handle_key_event(uint32_t keyCode, bool pressed)
         xkb_state_update_key(m_xkbState, keyCode, XKB_KEY_UP);
 
     // Call base class to update key state map
-    this->handle_keyboard_event(keysym, pressed);
+    this->handle_keyboard_event(keyCode, pressed);
 }
 
 void vkShade::InputBackendXcb::on_mouse_button(uint8_t button, bool pressed)

--- a/src/input/input_backend_xcb.cpp
+++ b/src/input/input_backend_xcb.cpp
@@ -116,10 +116,16 @@ void vkShade::InputBackendXcb::on_mouse_button(uint8_t button, bool pressed)
         case 1: mouseButton = MouseButton::LEFT; break;
         case 2: mouseButton = MouseButton::MIDDLE; break;
         case 3: mouseButton = MouseButton::RIGHT; break;
-        case 4:  // Scroll up
-        case 5:  // Scroll down
-            return;  // Ignore scroll for now
-        default: return;
+        case 4:
+            if (pressed)
+                this->handle_mouse_wheel_event(0.0f, 1.0f);
+            return;
+
+        case 5:
+            if (pressed)
+                this->handle_mouse_wheel_event(0.0f, -1.0f);
+        default:
+            return;
     }
 
     handle_mouse_button_event(mouseButton, pressed);

--- a/src/input/input_backend_xlib.cpp
+++ b/src/input/input_backend_xlib.cpp
@@ -58,21 +58,14 @@ void vkShade::InputBackendXlib::handle_key_event(uint32_t keyCode, bool pressed)
     if (!m_xkbState)
         return;
 
-    // Get keysym from XKB
-    xkb_keysym_t keysym = xkb_state_key_get_one_sym(m_xkbState, keyCode);
-
     // Update XKB state with this key event
     if (pressed)
-    {
         xkb_state_update_key(m_xkbState, keyCode, XKB_KEY_DOWN);
-    }
     else
-    {
         xkb_state_update_key(m_xkbState, keyCode, XKB_KEY_UP);
-    }
 
     // Call base class to update key state map
-    this->handle_keyboard_event(keysym, pressed);
+    this->handle_keyboard_event(keyCode, pressed);
 }
 
 

--- a/src/input/input_backend_xlib.cpp
+++ b/src/input/input_backend_xlib.cpp
@@ -20,6 +20,24 @@ vkShade::InputBackendXlib::InputBackendXlib(Display* display, Window window)
 
     // Initialize previous key states
     std::memset(m_previousKeymap, 0, sizeof(m_previousKeymap));
+
+    // Observe wheel button events without consuming the application's queue.
+    m_wheelDisplay = XOpenDisplay(DisplayString(m_display));
+    if (m_wheelDisplay)
+    {
+        XSelectInput(m_wheelDisplay, m_window, ButtonPressMask | ButtonReleaseMask);
+        XFlush(m_wheelDisplay);
+    }
+    else
+    {
+        Logger::warn("[Xlib] Could not open a display connection for mouse wheel input");
+    }
+}
+
+vkShade::InputBackendXlib::~InputBackendXlib()
+{
+    if (m_wheelDisplay)
+        XCloseDisplay(m_wheelDisplay);
 }
 
 void vkShade::InputBackendXlib::process_events()
@@ -48,6 +66,20 @@ void vkShade::InputBackendXlib::process_events()
 
     // Update previous state
     std::memcpy(m_previousKeymap, keymap, sizeof(keymap));
+
+    if (m_wheelDisplay)
+    {
+        while (XPending(m_wheelDisplay))
+        {
+            XEvent event {};
+            XNextEvent(m_wheelDisplay, &event);
+            if (event.type == ButtonPress
+                && (event.xbutton.button == Button4 || event.xbutton.button == Button5))
+            {
+                handle_mouse_wheel_event(0.0f, event.xbutton.button == Button4 ? 1.0f : -1.0f);
+            }
+        }
+    }
 
     // Query mouse state
     query_mouse_state();

--- a/src/input/input_backend_xlib.hpp
+++ b/src/input/input_backend_xlib.hpp
@@ -11,11 +11,13 @@ namespace vkShade
     {
     public:
         InputBackendXlib(Display* display, Window window);
+        ~InputBackendXlib();
 
         void process_events() override;
 
     private:
         Display* m_display;
+        Display* m_wheelDisplay {nullptr};
         Window   m_window;
         char     m_previousKeymap[32];  // Track previous keyboard state
 

--- a/src/input/input_events.hpp
+++ b/src/input/input_events.hpp
@@ -29,4 +29,10 @@ namespace vkShade
         MouseButton button;
         bool pressed {false};
     };
+
+    struct MouseWheelEvent
+    {
+        float x {0.0f};
+        float y {0.0f};
+    };
 } // namespace vkShade

--- a/src/input/input_events.hpp
+++ b/src/input/input_events.hpp
@@ -1,9 +1,23 @@
 #pragma once
 
+#include <string>
+
+#include "key_codes.hpp"
 #include "mouse_button_codes.hpp"
 
 namespace vkShade
 {
+    struct KeyboardEvent
+    {
+        KeyCode keyCode;
+        bool pressed;
+    };
+
+    struct TextInputEvent
+    {
+        std::string text;
+    };
+
     struct MouseMotionEvent
     {
         float x {0.0f};

--- a/src/input/input_events.hpp
+++ b/src/input/input_events.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "mouse_button_codes.hpp"
+
+namespace vkShade
+{
+    struct MouseMotionEvent
+    {
+        float x {0.0f};
+        float y {0.0f};
+    };
+
+    struct MouseButtonEvent
+    {
+        MouseButton button;
+        bool pressed {false};
+    };
+} // namespace vkShade

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -97,10 +97,23 @@ void vkShade::InputManager::bind_action(const std::string& actionName, vkShade::
     Logger::debug("Bound action '{}' to '{}'", actionName, magic_enum::enum_name(keyCode));
 }
 
-void vkShade::InputManager::handle_keyboard_event(const xkb_keysym_t& keysym, bool pressed)
+void vkShade::InputManager::handle_keyboard_event(const xkb_keycode_t& keycode, bool pressed)
 {
+    const xkb_keysym_t keysym = xkb_state_key_get_one_sym(m_xkbState, keycode);
+
     // Update key state map
     m_currentKeyStates[map_key(keysym)] = pressed;
+    m_eventBus.enqueue(KeyboardEvent{map_key(keysym), pressed});
+
+    if (!pressed)
+        return;
+
+    char buffer[64];
+    const int length = xkb_state_key_get_utf8(
+        m_xkbState, keycode, buffer, sizeof(buffer));
+
+    if (length > 0)
+        m_eventBus.enqueue(TextInputEvent{.text = std::string(buffer, length)});
 }
 
 void vkShade::InputManager::handle_mouse_button_event(MouseButton button, bool pressed)

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -126,6 +126,11 @@ void vkShade::InputManager::handle_mouse_motion_event(float x, float y)
     m_eventBus.enqueue(MouseMotionEvent{x, y});
 }
 
+void vkShade::InputManager::handle_mouse_wheel_event(float x, float y)
+{
+    m_eventBus.enqueue(MouseWheelEvent{x, y});
+}
+
 bool vkShade::InputManager::is_action_pressed(const std::string& actionName) const
 {
     auto it = m_actionBindings.find(actionName);

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -7,8 +7,10 @@
 
 #include "config/config_manager.hpp"
 #include "core/service_locator.hpp"
+#include "input_events.hpp"
 
 vkShade::InputManager::InputManager()
+    : m_eventBus(vkShade::Locator<EventBus>::get())
 {
     Logger::debug("Initializing InputManager");
 
@@ -103,14 +105,12 @@ void vkShade::InputManager::handle_keyboard_event(const xkb_keysym_t& keysym, bo
 
 void vkShade::InputManager::handle_mouse_button_event(MouseButton button, bool pressed)
 {
-    m_currentMouseStates[button] = pressed;
+    m_eventBus.enqueue(MouseButtonEvent{button, pressed});
 }
 
 void vkShade::InputManager::handle_mouse_motion_event(float x, float y)
 {
-    m_previousMousePosition = m_currentMousePosition;
-    m_currentMousePosition = glm::vec2(x, y);
-    m_mouseDelta = m_currentMousePosition - m_previousMousePosition;
+    m_eventBus.enqueue(MouseMotionEvent{x, y});
 }
 
 bool vkShade::InputManager::is_action_pressed(const std::string& actionName) const
@@ -129,28 +129,6 @@ bool vkShade::InputManager::is_action_just_released(const std::string& actionNam
 {
     auto it = m_actionBindings.find(actionName);
     return it != m_actionBindings.end() ? it->second.justReleased : false;
-}
-
-bool vkShade::InputManager::is_mouse_button_pressed(MouseButton button) const
-{
-    auto it = m_currentMouseStates.find(button);
-    return it != m_currentMouseStates.end() && it->second;
-}
-
-bool vkShade::InputManager::is_mouse_button_just_pressed(MouseButton button) const
-{
-    bool current = is_mouse_button_pressed(button);
-    auto it = m_previousMouseStates.find(button);
-    bool previous = it != m_previousMouseStates.end() && it->second;
-    return current && !previous;
-}
-
-bool vkShade::InputManager::is_mouse_button_just_released(MouseButton button) const
-{
-    bool current = is_mouse_button_pressed(button);
-    auto it = m_previousMouseStates.find(button);
-    bool previous = it != m_previousMouseStates.end() && it->second;
-    return !current && previous;
 }
 
 vkShade::KeyCode vkShade::InputManager::map_key(xkb_keysym_t keysym)

--- a/src/input/input_manager.hpp
+++ b/src/input/input_manager.hpp
@@ -45,6 +45,7 @@ namespace vkShade
         void handle_keyboard_event(const xkb_keycode_t& keycode, bool pressed);
         void handle_mouse_button_event(MouseButton button, bool pressed);
         void handle_mouse_motion_event(float x, float y);
+        void handle_mouse_wheel_event(float x, float y);
 
         void on_keybind_changed(const std::string& configKey, std::string enumString);
 

--- a/src/input/input_manager.hpp
+++ b/src/input/input_manager.hpp
@@ -4,6 +4,7 @@
 #include <unordered_map>
 
 #include <glm/vec2.hpp>
+#include <xkbcommon/xkbcommon.h>
 
 #include "core/event_bus.hpp"
 #include "key_codes.hpp"
@@ -41,7 +42,7 @@ namespace vkShade
         xkb_keymap*  m_xkbKeymap  {nullptr};
         xkb_state*   m_xkbState   {nullptr};
 
-        void handle_keyboard_event(const xkb_keysym_t& keysym, bool pressed);
+        void handle_keyboard_event(const xkb_keycode_t& keycode, bool pressed);
         void handle_mouse_button_event(MouseButton button, bool pressed);
         void handle_mouse_motion_event(float x, float y);
 

--- a/src/input/input_manager.hpp
+++ b/src/input/input_manager.hpp
@@ -5,6 +5,7 @@
 
 #include <glm/vec2.hpp>
 
+#include "core/event_bus.hpp"
 #include "key_codes.hpp"
 #include "mouse_button_codes.hpp"
 
@@ -29,14 +30,6 @@ namespace vkShade
         bool is_action_just_pressed(const std::string& actionName) const;
         bool is_action_just_released(const std::string& actionName) const;
 
-        // Mouse state
-        bool is_mouse_button_pressed(MouseButton button) const;
-        bool is_mouse_button_just_pressed(MouseButton button) const;
-        bool is_mouse_button_just_released(MouseButton button) const;
-
-        glm::vec2 mouse_position() const { return m_currentMousePosition; }
-        glm::vec2 mouse_delta() const { return m_mouseDelta; }
-
         virtual void process_events() = 0;
 
         void update();
@@ -55,6 +48,8 @@ namespace vkShade
         void on_keybind_changed(const std::string& configKey, std::string enumString);
 
     private:
+        EventBus& m_eventBus;
+
         struct ActionBinding
         {
             KeyCode keyCode;
@@ -67,13 +62,6 @@ namespace vkShade
 
         std::unordered_map<KeyCode, bool> m_currentKeyStates;
         std::unordered_map<KeyCode, bool> m_previousKeyStates;
-
-        glm::vec2 m_currentMousePosition {0.0f, 0.0f};
-        glm::vec2 m_previousMousePosition {0.0f, 0.0f};
-        glm::vec2 m_mouseDelta {0.0f, 0.0f};
-
-        std::unordered_map<MouseButton, bool> m_currentMouseStates;
-        std::unordered_map<MouseButton, bool> m_previousMouseStates;
 
         KeyCode map_key(xkb_keysym_t keysym);
     };

--- a/src/input/wayland_callbacks.cpp
+++ b/src/input/wayland_callbacks.cpp
@@ -31,19 +31,32 @@ static void kb_modifiers(void* data, wl_keyboard* kbd, uint32_t serial,
     static_cast<vkShade::InputBackendWayland*>(data)->on_keyboard_modifiers(mods_depressed, mods_latched, mods_locked, group);
 }
 
+void kb_repeat_info_handler(void* data, wl_keyboard* keyboard, int32_t rate, int32_t delay)
+{
+}
+
 // Seat callback
 static void seat_capabilities(void* data, wl_seat* seat, uint32_t caps)
 {
     static_cast<vkShade::InputBackendWayland*>(data)->on_seat_capabilities(seat, caps);
 }
 
+static void seat_name_handler(void* data, wl_seat* seat, const char* name)
+{
+}
+
 // Listener structs
 const wl_keyboard_listener kb_listener = {
-    kb_keymap, kb_enter, kb_leave, kb_key, kb_modifiers
+    .keymap = kb_keymap,
+    .enter = kb_enter,
+    .leave = kb_leave,
+    .key = kb_key,
+    .modifiers = kb_modifiers,
+    .repeat_info = kb_repeat_info_handler,
 };
 
 const wl_seat_listener seat_listener = {
-    seat_capabilities, NULL
+    seat_capabilities, seat_name_handler,
 };
 
 // Registry callback
@@ -87,6 +100,13 @@ void pointer_axis_handler(void* data, wl_pointer* pointer, uint32_t time,
     manager->on_pointer_axis(time, axis, value);
 }
 
+void pointer_axis_discrete_handler(void* data, wl_pointer* pointer,
+                                   uint32_t axis, int32_t discrete)
+{
+    auto* manager = static_cast<vkShade::InputBackendWayland*>(data);
+    manager->on_pointer_axis_discrete(axis, discrete);
+}
+
 void pointer_frame_handler(void* data, wl_pointer* pointer) {
     // Frame event - commits pointer events
 }
@@ -100,5 +120,5 @@ const wl_pointer_listener pointer_listener = {
     .frame = pointer_frame_handler,
     .axis_source = [](void*, wl_pointer*, uint32_t){},
     .axis_stop = [](void*, wl_pointer*, uint32_t, uint32_t){},
-    .axis_discrete = [](void*, wl_pointer*, uint32_t, int32_t){},
+    .axis_discrete = pointer_axis_discrete_handler,
 };


### PR DESCRIPTION
## Summary

Adds keyboard and mouse wheel support to all 3 input backends and the GUI.

## Changes

- Migrates input handling from API calls to events
- Removes now-redundant mouse state tracking
- Adds support for keyboard input (key press and text input)
- Adds support for mouse wheel input

## Testing

Manual testing using `vkcube` and all 3 input backends.

## Acknowledgements

Thanks to @kakra for front-running the X11 mouse wheel work, particularly the Xlib backend.