### PR TITLE
fix(hooks): remove misleading unsupported backend warning

### DIFF
--- a/src/hooks/hooks_surface.cpp
+++ b/src/hooks/hooks_surface.cpp
@@ -62,7 +62,6 @@ VK_LAYER_EXPORT VkResult vkShade_CreateXcbSurfaceKHR(VkInstance                 
         vkShade::Locator<vkShade::InputManager>::reset();
         vkShade::Locator<vkShade::InputManager>::emplace<vkShade::InputBackendXcb>(connection, window);
         vkShade::Logger::debug("X11 (XCB) surface created");
-        vkShade::Logger::warn("XCB input is currently unsupported");
     }
 
     return result;


### PR DESCRIPTION
The backend (XCB) is supported, so this warning is misleading and can cause users to incorrectly assume there is a compatibility issue.

Remove the obsolete warning.