### PR TITLE
feat(gui): add logs panel with filtering options

### DIFF
--- a/src/core/logger.hpp
+++ b/src/core/logger.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <memory>
+#include <spdlog/details/log_msg.h>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -9,6 +10,7 @@
 
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/ringbuffer_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace vkShade
@@ -19,6 +21,11 @@ namespace vkShade
     class Logger
     {
     public:
+        static std::vector<spdlog::details::log_msg_buffer> get_history()
+        {
+            return state().history->last_raw(m_historySize);
+        }
+
         static void trace(std::string_view msg)
         {
             get().trace(msg);
@@ -86,48 +93,84 @@ namespace vkShade
         }
 
     private:
+        static constexpr size_t m_historySize = 2000;
+
+        struct State
+        {
+            std::shared_ptr<spdlog::sinks::ringbuffer_sink_mt> history;
+            std::shared_ptr<spdlog::logger> logger;
+        };
+
         static spdlog::logger& get()
         {
-            // Keep the logger independent from spdlog's process-wide registry.
-            static auto logger = []
-            {
-                std::vector<spdlog::sink_ptr> sinks;
-                sinks.push_back(std::make_shared<spdlog::sinks::stderr_color_sink_mt>());
+            return *state().logger;
+        }
 
+        static State& state()
+        {
+            // Keep the logger independent from spdlog's process-wide registry.
+            static State instance = []
+            {
+                State state;
+
+                std::vector<spdlog::sink_ptr> sinks;
+
+                auto stderrSink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
+                sinks.push_back(stderrSink);
+
+                state.history = std::make_shared<spdlog::sinks::ringbuffer_sink_mt>(m_historySize);
+                state.history->set_level(spdlog::level::trace);
+                sinks.push_back(state.history);
+
+                spdlog::sink_ptr fileSink;
                 if (const char* path = std::getenv("VKSHADE_LOG_FILE"))
+                {
                     // Function-local static initialization opens and truncates the log
                     // exactly once, even when accessed concurrently from multiple threads.
-                    sinks.push_back(
-                        std::make_shared<spdlog::sinks::basic_file_sink_mt>(path, true));
+                    fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(path, true);
+                    sinks.push_back(fileSink);
+                }
 
-                auto result = std::make_shared<spdlog::logger>(
-                    "vkShade", sinks.begin(), sinks.end());
-                result->flush_on(spdlog::level::trace);
+                state.logger = std::make_shared<spdlog::logger>("vkShade", sinks.begin(), sinks.end());
 
                 const char* configuredLevel = std::getenv("VKSHADE_LOG_LEVEL");
                 const std::string level = configuredLevel ? configuredLevel : "info";
-                if (level == "trace")
-                    result->set_level(spdlog::level::trace);
-                else if (level == "debug")
-                    result->set_level(spdlog::level::debug);
-                else if (level == "info")
-                    result->set_level(spdlog::level::info);
-                else if (level == "warn" || level == "warning")
-                    result->set_level(spdlog::level::warn);
-                else if (level == "error")
-                    result->set_level(spdlog::level::err);
-                else if (level == "critical")
-                    result->set_level(spdlog::level::critical);
-                else if (level == "off")
-                    result->set_level(spdlog::level::off);
-                else
-                    result->set_level(spdlog::level::info);
 
-                result->debug("vkShade logger initialized");
-                return result;
+                spdlog::level::level_enum configuredLogLevel;
+
+                if (level == "trace")
+                    configuredLogLevel = spdlog::level::trace;
+                else if (level == "debug")
+                    configuredLogLevel = spdlog::level::debug;
+                else if (level == "info")
+                    configuredLogLevel = spdlog::level::info;
+                else if (level == "warn" || level == "warning")
+                    configuredLogLevel = spdlog::level::warn;
+                else if (level == "error")
+                    configuredLogLevel = spdlog::level::err;
+                else if (level == "critical")
+                    configuredLogLevel = spdlog::level::critical;
+                else if (level == "off")
+                    configuredLogLevel = spdlog::level::off;
+                else
+                    configuredLogLevel = spdlog::level::info;
+
+                // The logger must accept everything so the history sink
+                //  always receives trace messages.
+                state.logger->set_level(spdlog::level::trace);
+
+                // Apply the configured verbosity only to the external sinks.
+                stderrSink->set_level(configuredLogLevel);
+                state.logger->flush_on(configuredLogLevel);
+
+                if (fileSink)
+                    fileSink->set_level(configuredLogLevel);
+
+                state.logger->debug("vkShade logger initialized");
+                return state;
             }();
 
-            return *logger;
+            return instance;
         }
     };
 }

--- a/src/gui/meson.build
+++ b/src/gui/meson.build
@@ -1,5 +1,6 @@
 libgui_source = [
   'panels/effects_panel.cpp',
+  'panels/log_panel.cpp',
   'windows/about_window.cpp',
   'windows/main_window.cpp',
   'gui_manager.cpp',

--- a/src/gui/panels/effects_panel.hpp
+++ b/src/gui/panels/effects_panel.hpp
@@ -16,7 +16,7 @@ namespace vkShade
     public:
         EffectsPanel();
 
-        void render();
+        void render() override;
 
     private:
         ConfigStore& m_config;

--- a/src/gui/panels/log_panel.cpp
+++ b/src/gui/panels/log_panel.cpp
@@ -1,0 +1,295 @@
+#include "log_panel.hpp"
+
+#include "core/logger.hpp"
+#include "gui/gui_style.hpp"
+#include "imgui.h"
+
+std::string vkShade::LogPanel::format_log_line(const LogMessage& message)
+{
+    const std::string timestamp = format_timestamp(message.time);
+
+    const char* level = level_text(message.level);
+
+    std::string result;
+
+    result.reserve(timestamp.size() + 10 + message.payload.size());
+
+    result += timestamp;
+    result += level;
+    result.append(message.payload.data(), message.payload.size());
+
+    return result;
+}
+
+std::string vkShade::LogPanel::format_timestamp(const std::chrono::system_clock::time_point& time)
+{
+    using namespace std::chrono;
+
+    const auto time_t = system_clock::to_time_t(time);
+
+    std::tm tm{};
+    localtime_r(&time_t, &tm);
+
+    const auto milliseconds =
+        duration_cast<std::chrono::milliseconds>(time.time_since_epoch()) % 1000;
+
+    char timeBuffer[32];
+
+    std::strftime(timeBuffer, sizeof(timeBuffer), "[%H:%M:%S", &tm);
+
+    char buffer[64];
+
+    std::snprintf(buffer, sizeof(buffer),
+        "%s.%03lld]",
+        timeBuffer,
+        static_cast<long long>(milliseconds.count()));
+
+    return buffer;
+}
+
+const char* vkShade::LogPanel::level_text(spdlog::level::level_enum level)
+{
+    switch (level)
+    {
+        case spdlog::level::trace:    return "[trace]";
+        case spdlog::level::debug:    return "[debug]";
+        case spdlog::level::info:     return "[info] ";
+        case spdlog::level::warn:     return "[warn] ";
+        case spdlog::level::err:      return "[error]";
+        case spdlog::level::critical: return "[crit] ";
+        default:                      return "[?????]";
+    }
+}
+
+ImVec4 vkShade::LogPanel::level_color(spdlog::level::level_enum level)
+{
+    switch (level)
+    {
+        case spdlog::level::trace:
+            return UIStyle::Palette::WHITE;
+
+        case spdlog::level::debug:
+            return UIStyle::Palette::BLUE;
+
+        case spdlog::level::info:
+            return UIStyle::Palette::GREEN;
+
+        case spdlog::level::warn:
+            return UIStyle::Palette::YELLOW;
+
+        case spdlog::level::err:
+            return UIStyle::Palette::RED;
+
+        case spdlog::level::critical:
+            return UIStyle::Palette::RED;
+
+        default:
+            return ImGui::GetStyle().Colors[ImGuiCol_Text];
+    }
+}
+
+bool vkShade::LogPanel::passes_filter(const LogMessage& message) const
+{
+    if ((m_logLevelMask & (1u << message.level)) == 0)
+        return false;
+
+    if (m_filterBuffer[0] != '\0')
+    {
+        const std::string_view filter(m_filterBuffer);
+
+        const std::string_view payload(message.payload.data(), message.payload.size());
+
+        if (payload.find(filter) == std::string_view::npos)
+            return false;
+    }
+
+    return true;
+}
+
+void vkShade::LogPanel::render()
+{
+    render_control_bar();
+
+    ImGui::Separator();
+
+    render_log_messages();
+}
+
+void vkShade::LogPanel::render_control_bar()
+{
+    // Increase horizontal spacing between controls
+    ImVec2 spacing = ImGui::GetStyle().ItemSpacing;
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(spacing.x * 2.0f, spacing.y));
+
+    // TODO: Finish this after clipboard is supported
+    /*if (ImGui::Button("Copy"))
+    {
+        std::string text;
+
+        for (const auto& message : logHistory)
+        {
+            // Only copy what passes the filter
+            //if (!passes_filter(message))
+            //    continue;
+
+            text += format_log_line(message);
+            text += '\n';
+        }
+
+        ImGui::SetClipboardText(text.c_str());
+    }
+
+    ImGui::SameLine();
+    */
+
+    ImGui::Checkbox("Follow", &m_logFollow);
+
+    ImGui::SameLine();
+
+    // Level filter dropdown
+    {
+        std::string levelSummary;
+
+        const auto addLevelToSummary = [&](const char* name, spdlog::level::level_enum level)
+        {
+            if ((m_logLevelMask & (1u << level)) != 0)
+            {
+                if (!levelSummary.empty())
+                    levelSummary += ", ";
+
+                levelSummary += name;
+            }
+        };
+
+        addLevelToSummary("Error", spdlog::level::err);
+        addLevelToSummary("Warn",  spdlog::level::warn);
+        addLevelToSummary("Info",  spdlog::level::info);
+        addLevelToSummary("Debug", spdlog::level::debug);
+        addLevelToSummary("Trace", spdlog::level::trace);
+
+        if (levelSummary.empty())
+            levelSummary = "None";
+
+        // Calculate maximum width for combo box
+        const char* levels[] = {"Trace", "Debug", "Info", "Warn", "Error"};
+
+        std::string maxSummary {" "};
+        for (const char* level : levels)
+        {
+            if (!maxSummary.empty())
+                maxSummary += ", ";
+
+            maxSummary += level;
+        }
+
+        float comboWidth = ImGui::CalcTextSize(maxSummary.c_str()).x +
+                           ImGui::GetStyle().FramePadding.x * 2.0f +
+                           ImGui::GetStyle().ScrollbarSize;
+
+        ImGui::SetNextItemWidth(comboWidth);
+
+        const float comboHeight = ImGui::GetFrameHeightWithSpacing() * 8.0f;
+
+        ImGui::SetNextWindowSizeConstraints(ImVec2(0.0f, 0.0f), ImVec2(FLT_MAX, comboHeight));
+
+        if (ImGui::BeginCombo("##Levels", levelSummary.c_str()))
+        {
+            const auto toggleLevel = [&](const char* label, spdlog::level::level_enum level)
+            {
+                bool enabled = (m_logLevelMask & (1u << level)) != 0;
+
+                if (ImGui::Checkbox(label, &enabled))
+                {
+                    if (enabled)
+                        m_logLevelMask |= (1u << level);
+                    else
+                        m_logLevelMask &= ~(1u << level);
+                }
+            };
+
+            toggleLevel("Error",    spdlog::level::err);
+            toggleLevel("Warn",     spdlog::level::warn);
+            toggleLevel("Info",     spdlog::level::info);
+            toggleLevel("Debug",    spdlog::level::debug);
+            toggleLevel("Trace",    spdlog::level::trace);
+
+            ImGui::Separator();
+
+            if (ImGui::Button("All"))
+            {
+                m_logLevelMask = (1u << spdlog::level::trace) |
+                                 (1u << spdlog::level::debug) |
+                                 (1u << spdlog::level::info) |
+                                 (1u << spdlog::level::warn) |
+                                 (1u << spdlog::level::err);
+            }
+
+            ImGui::SameLine();
+
+            if (ImGui::Button("None"))
+                m_logLevelMask = 0;
+
+            ImGui::EndCombo();
+        }
+    } // Level filter dropdown
+
+    ImGui::SameLine();
+
+    // Text filter
+    {
+        ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+
+        ImGui::InputTextWithHint("##LogFilter", "Filter...",
+            m_filterBuffer, sizeof(m_filterBuffer));
+
+        ImGui::PopStyleVar();
+    }
+}
+
+void vkShade::LogPanel::render_log_messages()
+{
+    const auto logHistory = Logger::get_history();
+
+    ImGui::PushStyleColor(ImGuiCol_ChildBg, UIStyle::Palette::BACKGROUND);
+
+    if (ImGui::BeginChild("LogMessages", ImVec2(0, 0),false,
+        ImGuiWindowFlags_HorizontalScrollbar))
+    {
+        for (const auto& message : logHistory)
+        {
+            if (!passes_filter(message))
+                continue;
+
+            // Timestamp
+            const std::string timestamp = format_timestamp(message.time);
+            ImGui::TextDisabled("%s", timestamp.c_str());
+
+            ImGui::SameLine();
+
+            // Level
+            ImGui::PushStyleColor(ImGuiCol_Text, level_color(message.level));
+
+            ImGui::Text("%s", level_text(message.level));
+
+            ImGui::PopStyleColor();
+
+            ImGui::SameLine();
+
+            // Message
+            ImGui::PushStyleColor(ImGuiCol_Text, UIStyle::Palette::FOREGROUND);
+
+            ImGui::TextUnformatted(message.payload.data(),
+                message.payload.data() + message.payload.size());
+
+            ImGui::PopStyleColor();
+        }
+
+        // Follow
+        if (m_logFollow)
+            ImGui::SetScrollY(ImGui::GetScrollMaxY());
+    }
+
+    ImGui::EndChild();
+
+    ImGui::PopStyleColor();
+}

--- a/src/gui/panels/log_panel.hpp
+++ b/src/gui/panels/log_panel.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include "panel.hpp"
+
+#include <cstdint>
+
+#include <spdlog/spdlog.h>
+#include <imgui.h>
+
+namespace vkShade
+{
+    // Main GUI window
+    class LogPanel : public GuiPanel
+    {
+    public:
+        LogPanel() = default;
+
+        void render();
+
+    private:
+        using LogMessage = spdlog::details::log_msg_buffer;
+
+        bool m_logFollow = true;
+
+        uint32_t m_logLevelMask = (1u << spdlog::level::info) |
+                                  (1u << spdlog::level::warn) |
+                                  (1u << spdlog::level::err);
+
+        char m_filterBuffer[256] {};
+
+        void render_control_bar();
+        void render_log_messages();
+        void render_level_control();
+
+        bool passes_filter(const LogMessage& message) const;
+
+        static const char* level_text(spdlog::level::level_enum level);
+        static ImVec4 level_color(spdlog::level::level_enum level);
+
+        static std::string format_log_line(const LogMessage& message);
+        static std::string format_timestamp(const std::chrono::system_clock::time_point& time);
+    };
+} // namespace vkShade

--- a/src/gui/panels/log_panel.hpp
+++ b/src/gui/panels/log_panel.hpp
@@ -14,7 +14,7 @@ namespace vkShade
     public:
         LogPanel() = default;
 
-        void render();
+        void render() override;
 
     private:
         using LogMessage = spdlog::details::log_msg_buffer;

--- a/src/gui/windows/main_window.cpp
+++ b/src/gui/windows/main_window.cpp
@@ -27,6 +27,12 @@ void vkShade::MainWindow::render()
                 ImGui::EndTabItem();
             }
 
+            if (ImGui::BeginTabItem("Logs###logs"))
+            {
+                m_logPanel.render();
+                ImGui::EndTabItem();
+            }
+
             ImGui::EndTabBar();
         }
     }

--- a/src/gui/windows/main_window.hpp
+++ b/src/gui/windows/main_window.hpp
@@ -16,7 +16,7 @@ namespace vkShade
     public:
         MainWindow();
 
-        void render();
+        void render() override;
 
     private:
         ConfigStore& m_preset;

--- a/src/gui/windows/main_window.hpp
+++ b/src/gui/windows/main_window.hpp
@@ -4,6 +4,7 @@
 
 #include "config/config_store.hpp"
 #include "../panels/effects_panel.hpp"
+#include "../panels/log_panel.hpp"
 #include "../window.hpp"
 #include "about_window.hpp"
 
@@ -22,6 +23,7 @@ namespace vkShade
 
         // Panels
         EffectsPanel m_effectsPanel;
+        LogPanel     m_logPanel;
 
         // Sub-windows
         AboutWindow m_aboutWindow;


### PR DESCRIPTION
## Summary

Adds a `Logs` panel in the GUI, with a follow toggle and filtering options.

## Changes

- Add a ring buffer sink to the logger's internal state
- Ensure correct log level and flush behavior across all sinks
- Add a 'Logs' panel in the GUI with follow and filter controls
- Use raw log objects for filtering and formatting
- Colorize log levels using the previously established color palette

## Testing

Manual testing with `vkcube` and all 3 input backends.

- `VKSHADE_LOG_LEVEL` is respected for file and stderr sinks
- The ring buffer sink always operates independently at **trace** level
- Follow and filtering controls behave correctly
- Text input in the filter box works on all three input backends

## Acknowledgements

Thanks to @kakra for the exploratory work in #77.