### PR TITLE
feat(input): support horizontal X11 mouse wheel

### DIFF
--- a/src/input/input_backend_xcb.cpp
+++ b/src/input/input_backend_xcb.cpp
@@ -111,7 +111,7 @@ void vkShade::InputBackendXcb::handle_key_event(uint32_t keyCode, bool pressed)
 void vkShade::InputBackendXcb::on_mouse_button(uint8_t button, bool pressed)
 {
     // X11 button codes: 1=left, 2=middle, 3=right, 4/5=vertical
-    // wheel, 6/7=horizontal wheel (left/right).
+    // wheel (up/down), 6/7=horizontal wheel (left/right).
     MouseButton mouseButton;
     switch (button) {
         case 1: mouseButton = MouseButton::LEFT; break;

--- a/src/input/input_backend_xcb.cpp
+++ b/src/input/input_backend_xcb.cpp
@@ -110,7 +110,8 @@ void vkShade::InputBackendXcb::handle_key_event(uint32_t keyCode, bool pressed)
 
 void vkShade::InputBackendXcb::on_mouse_button(uint8_t button, bool pressed)
 {
-    // XCB button codes: 1=left, 2=middle, 3=right, 4=scroll up, 5=scroll down
+    // X11 button codes: 1=left, 2=middle, 3=right, 4/5=vertical
+    // wheel, 6/7=horizontal wheel (left/right).
     MouseButton mouseButton;
     switch (button) {
         case 1: mouseButton = MouseButton::LEFT; break;
@@ -124,6 +125,18 @@ void vkShade::InputBackendXcb::on_mouse_button(uint8_t button, bool pressed)
         case 5:
             if (pressed)
                 this->handle_mouse_wheel_event(0.0f, -1.0f);
+            return;
+
+        case 6:
+            if (pressed)
+                this->handle_mouse_wheel_event(1.0f, 0.0f);
+            return;
+
+        case 7:
+            if (pressed)
+                this->handle_mouse_wheel_event(-1.0f, 0.0f);
+            return;
+
         default:
             return;
     }

--- a/src/input/input_backend_xlib.cpp
+++ b/src/input/input_backend_xlib.cpp
@@ -74,9 +74,18 @@ void vkShade::InputBackendXlib::process_events()
             XEvent event {};
             XNextEvent(m_wheelDisplay, &event);
             if (event.type == ButtonPress
-                && (event.xbutton.button == Button4 || event.xbutton.button == Button5))
+                && event.xbutton.button >= Button4 && event.xbutton.button <= 7)
             {
-                handle_mouse_wheel_event(0.0f, event.xbutton.button == Button4 ? 1.0f : -1.0f);
+                if (event.xbutton.button <= Button5)
+                {
+                    handle_mouse_wheel_event(
+                        0.0f, event.xbutton.button == Button4 ? 1.0f : -1.0f);
+                }
+                else
+                {
+                    handle_mouse_wheel_event(
+                        event.xbutton.button == 6 ? 1.0f : -1.0f, 0.0f);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Add horizontal mouse-wheel input for the XCB and Xlib backends by mapping the conventional X11 wheel buttons:

- Button 6: scroll left
- Button 7: scroll right

Vertical wheel handling through buttons 4 and 5 remains unchanged.

Native Wayland already forwards both vertical and horizontal wheel axes, so this brings the X11 backends in line with the existing normalized input semantics.

## Testing

- Built successfully with Meson
- All six unit tests pass
- Manually tested vertical scrolling and horizontal wheel tilt in the vkShade overlay with ETS2 under XWayland using a Logitech G502 Lightspeed