### PR TITLE
fix(*): address safety issues

### DIFF
--- a/src/config/config_observer.hpp
+++ b/src/config/config_observer.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm>
 #include <functional>
 #include <string>
 #include <unordered_map>
@@ -51,20 +50,25 @@ namespace vkShade
         {
             std::string mapKey = section + "::" + key;
             auto it = m_subscribers.find(mapKey);
-            if (it != m_subscribers.end())
-            {
-                for (const auto& subscription : it->second)
-                {
-                    subscription.callback(&value, subscription.instance, key);
-                }
-            }
+
+            if (it == m_subscribers.end())
+                return;
+
+            std::vector<Subscription> snapshot = it->second;
+
+            for (const auto& subscription : snapshot)
+                subscription.callback(&value, subscription.instance, key);
         }
 
         void notify_all(ConfigStore& store)
         {
-            for (auto& [_, subscriptions] : m_subscribers)
-                for (auto& subscription : subscriptions)
-                    subscription.reload(store);
+            std::vector<Subscription> snapshot;
+
+            for (const auto& [_, subscriptions] : m_subscribers)
+                snapshot.insert(snapshot.end(), subscriptions.begin(), subscriptions.end());
+
+            for (auto& subscription : snapshot)
+                subscription.reload(store);
         }
 
     private:

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -31,9 +31,9 @@ vkShade::Runtime::Runtime(VulkanDevice& device, VkSwapchainKHR swapchain, VkSwap
 
     // Get swapchain images
     uint32_t imageCount = 0;
-    m_device.dispatch.GetSwapchainImagesKHR(m_device.handle, swapchain, &imageCount, nullptr);
+    VK_CHECK(m_device.dispatch.GetSwapchainImagesKHR(m_device.handle, swapchain, &imageCount, nullptr));
     std::vector<VkImage> images(imageCount);
-    m_device.dispatch.GetSwapchainImagesKHR(m_device.handle, swapchain, &imageCount, images.data());
+    VK_CHECK(m_device.dispatch.GetSwapchainImagesKHR(m_device.handle, swapchain, &imageCount, images.data()));
 
     // Create image views
     for (auto& image : images)
@@ -73,7 +73,7 @@ vkShade::Runtime::Runtime(VulkanDevice& device, VkSwapchainKHR swapchain, VkSwap
         .flags = VK_FENCE_CREATE_SIGNALED_BIT,
     };
 
-    m_device.dispatch.CreateFence(m_device.handle, &fenceInfo, nullptr, &m_fence);
+    VK_CHECK(m_device.dispatch.CreateFence(m_device.handle, &fenceInfo, nullptr, &m_fence));
 
     // Allocate command buffer
     VkCommandBufferAllocateInfo allocInfo = {
@@ -194,7 +194,7 @@ void vkShade::Runtime::render(uint32_t imageIndex)
         .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
         .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
     };
-    m_device.dispatch.BeginCommandBuffer(m_commandBuffer, &beginInfo);
+    VK_CHECK(m_device.dispatch.BeginCommandBuffer(m_commandBuffer, &beginInfo));
 
     // Blit swapchain image to ping-pong and transition to COLOR_ATTACHMENT
     swapchainImage->transition_layout(m_commandBuffer, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
@@ -270,7 +270,7 @@ void vkShade::Runtime::render(uint32_t imageIndex)
     swapchainImage->transition_layout(m_commandBuffer, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
     // End and submit
-    m_device.dispatch.EndCommandBuffer(m_commandBuffer);
+    VK_CHECK(m_device.dispatch.EndCommandBuffer(m_commandBuffer));
 
     VkSubmitInfo submitInfo = {
         .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
@@ -278,7 +278,7 @@ void vkShade::Runtime::render(uint32_t imageIndex)
         .pCommandBuffers = &m_commandBuffer,
     };
 
-    m_device.dispatch.QueueSubmit(m_device.queue, 1, &submitInfo, m_fence);
+    VK_CHECK(m_device.dispatch.QueueSubmit(m_device.queue, 1, &submitInfo, m_fence));
     m_frameCount++;
 }
 

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -16,6 +16,10 @@
 #include "vk/macros.hpp"
 #include "reshade_uniforms.hpp"
 
+// Give the layer's render submission up to 1 second to complete. A timeout
+//  indicates an abnormal GPU condition, so we will abort rather than hang.
+constexpr uint64_t FENCE_TIMEOUT_NS = 1'000'000'000;
+
 vkShade::Runtime::Runtime(VulkanDevice& device, VkSwapchainKHR swapchain, VkSwapchainCreateInfoKHR swapchainInfo)
     : VulkanObject(device)
 {
@@ -102,7 +106,7 @@ vkShade::Runtime::Runtime(VulkanDevice& device, VkSwapchainKHR swapchain, VkSwap
 vkShade::Runtime::~Runtime()
 {
     // Wait for the command buffer to finish executing
-    m_device.dispatch.WaitForFences(m_device.handle, 1, &m_fence, true, 1000000000);
+    VK_CHECK(m_device.dispatch.WaitForFences(m_device.handle, 1, &m_fence, VK_TRUE, FENCE_TIMEOUT_NS));
 
     // Clean up
     m_device.dispatch.DestroyCommandPool(m_device.handle, m_commandPool, nullptr);
@@ -123,7 +127,7 @@ void vkShade::Runtime::on_effects_changed(const std::string& key, std::vector<st
     auto searchPaths = config.get<std::vector<std::string>>("ReShade", "EffectSearchPaths");
 
     // Wait for the command buffer to finish executing
-    m_device.dispatch.WaitForFences(m_device.handle, 1, &m_fence, true, 1000000000);
+    VK_CHECK(m_device.dispatch.WaitForFences(m_device.handle, 1, &m_fence, VK_TRUE, FENCE_TIMEOUT_NS));
 
     m_effects.clear();
     std::vector<std::string> loadedEffects;
@@ -178,8 +182,8 @@ void vkShade::Runtime::render(uint32_t imageIndex)
     VulkanImage* swapchainImage = m_images.at(imageIndex).get();
     const auto reshadeFrameState = this->update_time();
 
-    // Wait until the previous command buffer has finished executing. Timeout of 1 second.
-	VK_CHECK(m_device.dispatch.WaitForFences(m_device.handle, 1, &m_fence, true, 1000000000));
+    // Wait until the previous command buffer has finished executing.
+	VK_CHECK(m_device.dispatch.WaitForFences(m_device.handle, 1, &m_fence, true, FENCE_TIMEOUT_NS));
 	VK_CHECK(m_device.dispatch.ResetFences(m_device.handle, 1, &m_fence));
 
     // Reset the command buffer

--- a/src/vk/image.cpp
+++ b/src/vk/image.cpp
@@ -387,13 +387,13 @@ void vkShade::VulkanImage::upload(const void* data, size_t size)
 
     // NOTE: Command buffers are dispatchable types. Their creation must go through our
     //  own hook, not the dispatch table, to ensure the dispatch pointer fixup runs.
-    vkShade_AllocateCommandBuffers(m_device.handle, &cmdBufAllocInfo, &cmd);
+    VK_CHECK(vkShade_AllocateCommandBuffers(m_device.handle, &cmdBufAllocInfo, &cmd));
 
     VkCommandBufferBeginInfo beginInfo = {
         .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
         .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
     };
-    m_device.dispatch.BeginCommandBuffer(cmd, &beginInfo);
+    VK_CHECK(m_device.dispatch.BeginCommandBuffer(cmd, &beginInfo));
 
     // Transition UNDEFINED -> TRANSFER_DST_OPTIMAL
     this->transition_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
@@ -418,7 +418,7 @@ void vkShade::VulkanImage::upload(const void* data, size_t size)
     // Transition TRANSFER_DST_OPTIMAL -> SHADER_READ_ONLY_OPTIMAL
     this->transition_layout(cmd, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
-    m_device.dispatch.EndCommandBuffer(cmd);
+    VK_CHECK(m_device.dispatch.EndCommandBuffer(cmd));
 
     VkSubmitInfo submitInfo = {
         .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,


### PR DESCRIPTION
Addresses several latent safety issues across the layer:

- Add missing error handling for fatal Vulkan calls
- Check fence waits and centralize the render fence timeout
- Prevent iterator invalidation when config callbacks modify subscriptions during dispatch

These changes make several existing failure paths explicit and avoid undefined behavior in the configuration callback path.