### PR TITLE
fix(config): improve INI loading and preset support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,4 +73,5 @@ venv:
 clean:
 	rm -rf $(BUILD_DIR)
 	rm -rf $(BUILD32_DIR)
+	meson subprojects purge --confirm
 	rm -rf docs/content/reference/generated/csharp venv

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('vkShade', ['c', 'cpp'], version: files('VERSION'),
-  default_options: ['c_std=c11', 'cpp_std=c++23', 'b_ndebug=if-release'])
+  default_options: ['c_std=c11', 'cpp_std=c++23', 'b_ndebug=if-release', 'force_fallback_for=inih'])
 
 cpp = meson.get_compiler('cpp')
 

--- a/src/config/config_store.cpp
+++ b/src/config/config_store.cpp
@@ -48,20 +48,30 @@ bool vkShade::ConfigStore::load(std::filesystem::path filePath)
     if ((perms & std::filesystem::perms::owner_read) == std::filesystem::perms::none)
         return false;
 
-    // Clear existing state if there is any
-    m_watcher.reset();
-    this->clear();
-
     // Parse the INI file
-    int result = ini_parse(filePath.string().c_str(), config_ini_handler, &m_config);
+    std::unordered_map<std::string, std::string> config;
+    int result = ini_parse(filePath.string().c_str(), config_ini_handler, &config);
     if (result != 0)
     {
-        Logger::error("Failed to load or parse config file: {}", filePath.c_str());
+        if (result > 0)
+            Logger::error("Failed to parse file at line {}: {}", result, filePath.string());
+        else if (result == -1)
+            Logger::error("Failed to open file for parsing: {}", filePath.string());
+        else
+            Logger::error("Failed to parse file (error {}): {}", result, filePath.string());
+
         return false;
     }
 
+    // Clear old state
+    m_watcher.reset();
+    this->clear();
+
+    // Commit new state
+    m_config = std::move(config);
     m_observer.notify_all(*this);
 
+    // Set up the file watcher
     m_watcher = Platform::FileWatcher::create();
     m_watcher->watch(filePath);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,7 +9,9 @@ version_hpp = declare_dependency(
 
 glm = dependency('glm', fallback: ['glm', 'glm_dep'])
 imgui = dependency('imgui-docking', fallback: ['imgui-docking', 'imgui_dep'], static: true)
-inih = dependency('inih', fallback: ['inih', 'inih_dep'], static: true)
+inih = dependency('inih', fallback: ['inih', 'inih_dep'], static: true,
+  default_options: ['distro_install=false', 'with_INIReader=false', 'tests=false', 'max_line_length=65536']
+)
 magic_enum = dependency('magic_enum', fallback: ['magic_enum', 'magic_enum_dep'])
 reshadefx = dependency('reshadefx', fallback: ['reshadefx', 'reshadefx_dep'])
 spdlog = dependency('spdlog', fallback: ['spdlog', 'spdlog_dep'], static: true)


### PR DESCRIPTION
ReShade presets can contain very long `TechniqueSorting` lines that exceed inih's default 200-byte limit. This PR increases the parser limit and ensures the vendored inih build is used.

It also improves configuration load diagnostics and makes loading atomic, so a failed parse cannot leave partially applied state.

See #118 
