### PR TITLE
fix(runtime): make effect reloads recoverable and lifetime-safe

### DIFF
--- a/src/config/config_observer.hpp
+++ b/src/config/config_observer.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <algorithm>
 #include <functional>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -54,21 +56,23 @@ namespace vkShade
             if (it == m_subscribers.end())
                 return;
 
-            std::vector<Subscription> snapshot = it->second;
+            const auto snapshot = it->second;
 
             for (const auto& subscription : snapshot)
-                subscription.callback(&value, subscription.instance, key);
+                if (subscription->connected)
+                    subscription->callback(&value, subscription->instance, key);
         }
 
         void notify_all(ConfigStore& store)
         {
-            std::vector<Subscription> snapshot;
+            std::vector<std::shared_ptr<Subscription>> snapshot;
 
             for (const auto& [_, subscriptions] : m_subscribers)
                 snapshot.insert(snapshot.end(), subscriptions.begin(), subscriptions.end());
 
-            for (auto& subscription : snapshot)
-                subscription.reload(store);
+            for (const auto& subscription : snapshot)
+                if (subscription->connected)
+                    subscription->reload(store);
         }
 
     private:
@@ -76,6 +80,7 @@ namespace vkShade
 
         struct Subscription
         {
+            bool connected {true};
             std::string section;
             std::string key;
 
@@ -86,8 +91,10 @@ namespace vkShade
             std::function<void(ConfigStore&)> reload;
         };
 
-        // Map: "Section::Key" -> [Subscription]
-        std::unordered_map<std::string, std::vector<Subscription>> m_subscribers;
+        // Snapshots share each node's connection state with the live list, so
+        // disconnecting a handler suppresses it without a second lookup index.
+        using SubscriptionPtr = std::shared_ptr<Subscription>;
+        std::unordered_map<std::string, std::vector<SubscriptionPtr>> m_subscribers;
 
         // Helper traits
         template<typename T>

--- a/src/config/config_observer.inl
+++ b/src/config/config_observer.inl
@@ -23,26 +23,26 @@ namespace vkShade
 
         // Check if already connected
         auto& handlers = m_subscribers[mapKey];
-        for (const auto& sub : handlers)
-        {
-            if (sub.function == pFunction && sub.instance == nullptr)
-                return;  // Already connected
-        }
+        if (std::ranges::any_of(handlers, [pFunction](const SubscriptionPtr& sub)
+            {
+                return sub->function == pFunction && sub->instance == nullptr;
+            }))
+            return;  // Already connected
 
         // If not, create a new subscription.
-        Subscription subscription;
+        auto subscription = std::make_shared<Subscription>();
 
-        subscription.section = section;
-        subscription.key = key;
-        subscription.function = pFunction;
-        subscription.instance = nullptr;
+        subscription->section = section;
+        subscription->key = key;
+        subscription->function = pFunction;
+        subscription->instance = nullptr;
 
-        subscription.callback = [](const void* pValue, void*, const std::string& k)
+        subscription->callback = [](const void* pValue, void*, const std::string& k)
         {
             Func(k, *static_cast<const ArgType*>(pValue));
         };
 
-        subscription.reload = [section, key](ConfigStore& store)
+        subscription->reload = [section, key](ConfigStore& store)
         {
             auto value = store.get<ArgType>(section, key);
 
@@ -71,27 +71,27 @@ namespace vkShade
 
         // Check if already connected
         auto& handlers = m_subscribers[mapKey];
-        for (const auto& sub : handlers)
-        {
-            if (sub.function == pMethod && sub.instance == instance)
-                return;  // Already connected
-        }
+        if (std::ranges::any_of(handlers, [pMethod, instance](const SubscriptionPtr& sub)
+            {
+                return sub->function == pMethod && sub->instance == instance;
+            }))
+            return;  // Already connected
 
         // If not then create a new subscription
-        Subscription subscription;
+        auto subscription = std::make_shared<Subscription>();
 
-        subscription.section = section;
-        subscription.key = key;
-        subscription.function = pMethod;
-        subscription.instance = instance;
+        subscription->section = section;
+        subscription->key = key;
+        subscription->function = pMethod;
+        subscription->instance = instance;
 
-        subscription.callback = [](const void* pValue, void* pInstance, const std::string& k)
+        subscription->callback = [](const void* pValue, void* pInstance, const std::string& k)
         {
             Class* obj = static_cast<Class*>(pInstance);
             (obj->*Method)(k, *static_cast<const ArgType*>(pValue));
         };
 
-        subscription.reload = [instance, section, key](ConfigStore& store)
+        subscription->reload = [instance, section, key](ConfigStore& store)
         {
             auto value = store.get<ArgType>(section, key);
             if (value)
@@ -113,9 +113,12 @@ namespace vkShade
         {
             auto& handlers = it->second;
             handlers.erase(std::remove_if(handlers.begin(), handlers.end(),
-                [pFunction](const Subscription& sub)
+                [pFunction](const SubscriptionPtr& sub)
                 {
-                    return sub.function == pFunction && sub.instance == nullptr;
+                    const bool matches = sub->function == pFunction && sub->instance == nullptr;
+                    if (matches)
+                        sub->connected = false;
+                    return matches;
                 }),
                 handlers.end()
             );
@@ -146,9 +149,12 @@ namespace vkShade
         {
             auto& handlers = it->second;
             handlers.erase(std::remove_if(handlers.begin(), handlers.end(),
-                [pMethod, instance](const Subscription& sub)
+                [pMethod, instance](const SubscriptionPtr& sub)
                 {
-                    return sub.function == pMethod && sub.instance == instance;
+                    const bool matches = sub->function == pMethod && sub->instance == instance;
+                    if (matches)
+                        sub->connected = false;
+                    return matches;
                 }),
                 handlers.end()
             );

--- a/src/runtime/effect_reload_state.hpp
+++ b/src/runtime/effect_reload_state.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <vulkan/vulkan_core.h>
+
+namespace vkShade
+{
+    class EffectReloadState
+    {
+    public:
+        void request(std::vector<std::string> effects)
+        {
+            m_pendingEffects = std::move(effects);
+        }
+
+        [[nodiscard]] bool pending() const
+        {
+            return m_pendingEffects.has_value();
+        }
+
+        template<typename Apply>
+        bool apply_if_safe(VkResult fenceResult, Apply&& apply)
+        {
+            if (fenceResult != VK_SUCCESS || !m_pendingEffects)
+                return false;
+
+            // Consume before invoking so a request made while applying is not
+            // erased as part of completing the older request.
+            auto effects = std::move(*m_pendingEffects);
+            m_pendingEffects.reset();
+            std::invoke(std::forward<Apply>(apply), effects);
+            return true;
+        }
+
+    private:
+        std::optional<std::vector<std::string>> m_pendingEffects;
+    };
+}  // namespace vkShade

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -16,8 +16,8 @@
 #include "vk/macros.hpp"
 #include "reshade_uniforms.hpp"
 
-// Give the layer's render submission up to 1 second to complete. A timeout
-//  indicates an abnormal GPU condition, so we will abort rather than hang.
+// Bound fence waits so active rendering can yield after a transient stall
+// instead of blocking the application's present thread indefinitely.
 constexpr uint64_t FENCE_TIMEOUT_NS = 1'000'000'000;
 
 vkShade::Runtime::Runtime(VulkanDevice& device, VkSwapchainKHR swapchain, VkSwapchainCreateInfoKHR swapchainInfo)
@@ -123,14 +123,17 @@ vkShade::Runtime::~Runtime()
 
 void vkShade::Runtime::on_effects_changed(const std::string& key, std::vector<std::string> effects)
 {
+    m_effectReload.request(std::move(effects));
+}
+
+void vkShade::Runtime::reload_effects(const std::vector<std::string>& effects)
+{
     auto& config = vkShade::Locator<vkShade::ConfigManager>::get().app();
     auto searchPaths = config.get<std::vector<std::string>>("ReShade", "EffectSearchPaths");
 
-    // Wait for the command buffer to finish executing
-    VK_CHECK(m_device.dispatch.WaitForFences(m_device.handle, 1, &m_fence, VK_TRUE, FENCE_TIMEOUT_NS));
-
-    m_effects.clear();
+    std::vector<std::shared_ptr<ReshadeEffect>> newEffects;
     std::vector<std::string> loadedEffects;
+    bool complete = true;
     for (const auto& effect : effects)
     {
         bool found = false;
@@ -149,7 +152,7 @@ void vkShade::Runtime::on_effects_changed(const std::string& key, std::vector<st
                                 .format = m_format,
                                 .colorSpace = m_colorSpace,
                             };
-                            m_effects.push_back(std::make_shared<ReshadeEffect>(m_device, swapchainInfo, entry.path()));
+                            newEffects.push_back(std::make_shared<ReshadeEffect>(m_device, swapchainInfo, entry.path()));
                             loadedEffects.push_back(effect);
                             found = true;
                         } catch (const std::runtime_error& exception) {
@@ -164,7 +167,20 @@ void vkShade::Runtime::on_effects_changed(const std::string& key, std::vector<st
 
         if (!found && !error)
             Logger::warn("Unable to find effect: {}", effect);
+
+        if (!found)
+            complete = false;
     }
+
+    if (!complete)
+    {
+        Logger::warn("Keeping the active effect chain because its replacement is incomplete");
+        return;
+    }
+
+    // Keep the old chain usable until every requested replacement has been
+    // created successfully, then release it only after the fence is idle.
+    m_effects.swap(newEffects);
 
     auto& internalCfg = vkShade::Locator<vkShade::ConfigManager>::get().internal();
     internalCfg.set("__INTERNAL__", "LoadedEffects", loadedEffects);
@@ -182,8 +198,29 @@ void vkShade::Runtime::render(uint32_t imageIndex)
     VulkanImage* swapchainImage = m_images.at(imageIndex).get();
     const auto reshadeFrameState = this->update_time();
 
-    // Wait until the previous command buffer has finished executing.
-	VK_CHECK(m_device.dispatch.WaitForFences(m_device.handle, 1, &m_fence, true, FENCE_TIMEOUT_NS));
+    // Effect resources may only be replaced after the command buffer that uses them is idle.
+    const VkResult fenceResult =
+        m_device.dispatch.WaitForFences(m_device.handle, 1, &m_fence, true, FENCE_TIMEOUT_NS);
+    if (fenceResult == VK_TIMEOUT)
+    {
+        if (!m_fenceWaitTimedOut)
+            Logger::warn("Render fence timed out; retaining GPU resources and retrying");
+        m_fenceWaitTimedOut = true;
+        return;
+    }
+    VK_CHECK(fenceResult);
+
+    if (m_fenceWaitTimedOut)
+    {
+        Logger::info("Render fence recovered after a timeout");
+        m_fenceWaitTimedOut = false;
+    }
+
+    m_effectReload.apply_if_safe(fenceResult, [this](const auto& effects)
+    {
+        reload_effects(effects);
+    });
+
 	VK_CHECK(m_device.dispatch.ResetFences(m_device.handle, 1, &m_fence));
 
     // Reset the command buffer

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -6,6 +6,7 @@
 #include <vulkan/vulkan_core.h>
 
 #include "core/events/reload_effects.hpp"
+#include "effect_reload_state.hpp"
 #include "vk/object.hpp"
 #include "reshade_effect.hpp"
 
@@ -46,6 +47,8 @@ namespace vkShade
         VkFence m_fence {VK_NULL_HANDLE};
         VkCommandPool m_commandPool {VK_NULL_HANDLE};
         VkCommandBuffer m_commandBuffer {VK_NULL_HANDLE};
+        EffectReloadState m_effectReload;
+        bool m_fenceWaitTimedOut {false};
         std::vector<std::shared_ptr<ReshadeEffect>> m_effects;
         std::shared_ptr<VulkanImage> m_pingPongA;
         std::shared_ptr<VulkanImage> m_pingPongB;
@@ -57,5 +60,7 @@ namespace vkShade
 
         [[nodiscard]]
         ReshadeFrameState update_time();
+
+        void reload_effects(const std::vector<std::string>& effects);
     };
 }  // namespace vkShade

--- a/tests/config_observer_tests.cpp
+++ b/tests/config_observer_tests.cpp
@@ -68,6 +68,46 @@ private:
     uint32_t m_callCount = 0;
 };
 
+class ObserverReplacementListener
+{
+public:
+    void on_value(const std::string&, const std::string&)
+    {
+        callCount++;
+    }
+
+    uint32_t callCount {0};
+};
+
+class ObserverMutationListener
+{
+public:
+    ObserverMutationListener(ConfigObserver& observer,
+                             ObserverReplacementListener& removed,
+                             ObserverReplacementListener& replacement)
+        : m_observer(observer),
+          m_removed(removed),
+          m_replacement(replacement)
+    {
+    }
+
+    void on_value(const std::string&, const std::string&)
+    {
+        callCount++;
+        m_observer.on_changed("test", "value")
+            .disconnect<&ObserverReplacementListener::on_value>(&m_removed);
+        m_observer.on_changed("test", "value")
+            .connect<&ObserverReplacementListener::on_value>(&m_replacement);
+    }
+
+    uint32_t callCount {0};
+
+private:
+    ConfigObserver& m_observer;
+    ObserverReplacementListener& m_removed;
+    ObserverReplacementListener& m_replacement;
+};
+
 TEST_CASE("ConfigObserver: Connect free function and notify", "[config][observer]")
 {
     g_callbackLog.clear();
@@ -106,6 +146,30 @@ TEST_CASE("ConfigObserver: Multiple handlers for same key", "[config][observer]"
     REQUIRE(g_callbackLog[0] == "string:hello");
     REQUIRE(listener.get_call_count() == 1);
     REQUIRE(listener.get_last_string() == "hello");
+}
+
+TEST_CASE("ConfigObserver: Subscription changes take effect on the next notification",
+          "[config][observer]")
+{
+    ConfigObserver observer;
+    ObserverReplacementListener removed;
+    ObserverReplacementListener replacement;
+    ObserverMutationListener mutation(observer, removed, replacement);
+
+    observer.on_changed("test", "value")
+        .connect<&ObserverMutationListener::on_value>(&mutation);
+    observer.on_changed("test", "value")
+        .connect<&ObserverReplacementListener::on_value>(&removed);
+
+    observer.notify("test", "value", std::string("first"));
+    CHECK(mutation.callCount == 1);
+    CHECK(removed.callCount == 0);
+    CHECK(replacement.callCount == 0);
+
+    observer.notify("test", "value", std::string("second"));
+    CHECK(mutation.callCount == 2);
+    CHECK(removed.callCount == 0);
+    CHECK(replacement.callCount == 1);
 }
 
 TEST_CASE("ConfigObserver: Different sections and keys don't interfere", "[config][observer]")

--- a/tests/config_store_tests.cpp
+++ b/tests/config_store_tests.cpp
@@ -44,6 +44,46 @@ private:
     std::filesystem::path m_path;
 };
 
+class ReloadReplacementListener
+{
+public:
+    void on_value(const std::string&, const std::string&)
+    {
+        callCount++;
+    }
+
+    uint32_t callCount {0};
+};
+
+class ReloadMutationListener
+{
+public:
+    ReloadMutationListener(ConfigStore& config,
+                           ReloadReplacementListener& removed,
+                           ReloadReplacementListener& replacement)
+        : m_config(config),
+          m_removed(removed),
+          m_replacement(replacement)
+    {
+    }
+
+    void on_value(const std::string&, const std::string&)
+    {
+        callCount++;
+        m_config.on_changed("reload", "value")
+            .disconnect<&ReloadReplacementListener::on_value>(&m_removed);
+        m_config.on_changed("reload", "value")
+            .connect<&ReloadReplacementListener::on_value>(&m_replacement);
+    }
+
+    uint32_t callCount {0};
+
+private:
+    ConfigStore& m_config;
+    ReloadReplacementListener& m_removed;
+    ReloadReplacementListener& m_replacement;
+};
+
 TEST_CASE("ConfigStore: Set and get string", "[config][manager]")
 {
     ConfigStore config(ConfigStore::Type::Internal);
@@ -221,6 +261,34 @@ TEST_CASE("ConfigStore: Load from file", "[config][manager]")
     REQUIRE(*vsync == true);
     REQUIRE(volume.has_value());
     REQUIRE_THAT(*volume, Catch::Matchers::WithinRel(0.75f, 0.01f));
+}
+
+TEST_CASE("ConfigStore: Reload tolerates subscription changes from callbacks",
+          "[config][manager][observer]")
+{
+    TempConfigFile tempFile("test_reload_subscription_mutation.ini");
+    tempFile.write("[reload]\nvalue = first\n");
+
+    ConfigStore config(ConfigStore::Type::Internal);
+    ReloadReplacementListener removed;
+    ReloadReplacementListener replacement;
+    ReloadMutationListener mutation(config, removed, replacement);
+
+    config.on_changed("reload", "value")
+        .connect<&ReloadMutationListener::on_value>(&mutation);
+    config.on_changed("reload", "value")
+        .connect<&ReloadReplacementListener::on_value>(&removed);
+
+    REQUIRE(config.load(tempFile.path()));
+    CHECK(mutation.callCount == 1);
+    CHECK(removed.callCount == 0);
+    CHECK(replacement.callCount == 0);
+
+    tempFile.write("[reload]\nvalue = second\n");
+    REQUIRE(config.load(tempFile.path()));
+    CHECK(mutation.callCount == 2);
+    CHECK(removed.callCount == 0);
+    CHECK(replacement.callCount == 1);
 }
 
 TEST_CASE("ConfigStore: Load non-existent file does nothing", "[config][manager]")

--- a/tests/effect_reload_state_tests.cpp
+++ b/tests/effect_reload_state_tests.cpp
@@ -1,0 +1,61 @@
+#include "runtime/effect_reload_state.hpp"
+
+#include <string>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace vkShade;
+
+TEST_CASE("Effect reload waits for GPU resources to become idle", "[runtime][reload]")
+{
+    EffectReloadState reload;
+    std::vector<std::string> appliedEffects;
+    uint32_t applyCount = 0;
+
+    reload.request({"Old.fx"});
+    reload.request({"Latest.fx"});
+
+    CHECK_FALSE(reload.apply_if_safe(VK_TIMEOUT, [&](const auto& effects)
+    {
+        appliedEffects = effects;
+        applyCount++;
+    }));
+    CHECK(reload.pending());
+    CHECK(applyCount == 0);
+
+    CHECK(reload.apply_if_safe(VK_SUCCESS, [&](const auto& effects)
+    {
+        appliedEffects = effects;
+        applyCount++;
+    }));
+    CHECK_FALSE(reload.pending());
+    CHECK(applyCount == 1);
+    REQUIRE(appliedEffects.size() == 1);
+    CHECK(appliedEffects.front() == "Latest.fx");
+}
+
+TEST_CASE("Effect reload preserves requests made while applying", "[runtime][reload]")
+{
+    EffectReloadState reload;
+    std::vector<std::string> appliedEffects;
+
+    reload.request({"Current.fx"});
+    REQUIRE(reload.apply_if_safe(VK_SUCCESS, [&](const auto& effects)
+    {
+        appliedEffects = effects;
+        reload.request({"Next.fx"});
+    }));
+
+    CHECK(reload.pending());
+    REQUIRE(appliedEffects.size() == 1);
+    CHECK(appliedEffects.front() == "Current.fx");
+
+    REQUIRE(reload.apply_if_safe(VK_SUCCESS, [&](const auto& effects)
+    {
+        appliedEffects = effects;
+    }));
+    CHECK_FALSE(reload.pending());
+    REQUIRE(appliedEffects.size() == 1);
+    CHECK(appliedEffects.front() == "Next.fx");
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -47,8 +47,17 @@ reshade_uniform_tests = executable('reshade_uniform_tests',
   include_directories : include_directories('../src')
 )
 
+effect_reload_state_tests = executable('effect_reload_state_tests',
+  'effect_reload_state_tests.cpp',
+  dependencies : [
+    catch2,
+  ],
+  include_directories : include_directories('../src')
+)
+
 test('ConfigObserver', config_observer_tests)
 test('ConfigParser', config_parser_tests)
 test('ConfigStore', config_store_tests)
 test('EventBus', event_bus_tests)
 test('ReshadeUniforms', reshade_uniform_tests)
+test('EffectReloadState', effect_reload_state_tests)


### PR DESCRIPTION
## Summary

This PR addresses two remaining failure modes around configuration notifications and live effect reloads:

- avoid invoking subscriptions that were disconnected while a notification snapshot was being dispatched
- defer effect replacement until the runtime fence has completed successfully
- treat a fence timeout as a recoverable condition rather than proof of device loss
- keep the existing effect chain active until its complete replacement has been constructed

## Motivation

The recent configuration changes substantially improve reload behavior: configuration files are parsed atomically, parse failures preserve the active configuration, and fence waits are bounded instead of potentially blocking forever.

A bounded wait alone does not fully cover transient stalls, however. `VK_TIMEOUT` only means that the fence did not signal within the selected interval; it does not imply that the device or application can no longer recover. Passing that result through `VK_CHECK` can therefore terminate an otherwise recoverable application depending on scheduling, I/O pressure, screenshot capture, or temporary GPU load.

There is also a separate callback-lifetime edge case. Configuration notifications iterate over a snapshot of subscribers. An earlier callback may disconnect and destroy a later subscriber while that snapshot is still being dispatched. Removing it from the live subscription list does not invalidate the already captured snapshot, so the later callback may still be invoked through a stale object pointer.

These cases became visible while repeatedly editing and reloading an effect chain under additional screenshot and I/O load.

## Approach

The first commit gives notification snapshots shared ownership of small subscription nodes. Disconnecting a subscription marks its node inactive before removing it from the live list. An in-progress snapshot can therefore skip it safely without requiring a second synchronized lookup structure. Subscriptions added during dispatch remain deferred until the next notification.

The second commit changes effect reloads into pending requests:

1. Configuration and GUI callbacks only record the latest requested effect list.
2. The render path waits for the existing frame fence.
3. On `VK_TIMEOUT`, vkShade skips its work for that presentation, retains the current GPU resources and pending request, and retries later.
4. After `VK_SUCCESS`, the replacement effect chain is built separately.
5. The active chain is exchanged only when the complete replacement was constructed successfully.

Timeout and recovery messages are emitted only on state transitions to avoid repeating the same warning every frame.

## Tests

The included tests cover:

- disconnecting a later callback during snapshot dispatch
- destroying an observer from an earlier configuration callback
- coalescing pending reload requests across a timeout
- preserving a new request made while an older request is being applied

All seven tests available on this isolated branch pass, and the complete project builds successfully.

The tests are primarily included to document the less obvious lifetime and state-transition cases. I am happy for them to be simplified, reworked, or omitted if the project prefers to keep this behavior covered differently.