### PR TITLE
fix(config): silent reload failures and use-after-free during notification

### DIFF
--- a/src/config/config_observer.hpp
+++ b/src/config/config_observer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -57,7 +58,8 @@ namespace vkShade
             std::vector<Subscription> snapshot = it->second;
 
             for (const auto& subscription : snapshot)
-                subscription.callback(&value, subscription.instance, key);
+                if (*subscription.alive)
+                    subscription.callback(&value, subscription.instance, key);
         }
 
         void notify_all(ConfigStore& store)
@@ -68,7 +70,8 @@ namespace vkShade
                 snapshot.insert(snapshot.end(), subscriptions.begin(), subscriptions.end());
 
             for (auto& subscription : snapshot)
-                subscription.reload(store);
+                if (*subscription.alive)
+                    subscription.reload(store);
         }
 
     private:
@@ -84,6 +87,9 @@ namespace vkShade
 
             Callback callback;
             std::function<void(ConfigStore&)> reload;
+
+            // Track liveness so we don't use-after-free in snapshots
+            std::shared_ptr<bool> alive = std::make_shared<bool>(true);
         };
 
         // Map: "Section::Key" -> [Subscription]

--- a/src/config/config_observer.inl
+++ b/src/config/config_observer.inl
@@ -45,9 +45,7 @@ namespace vkShade
         subscription.reload = [section, key](ConfigStore& store)
         {
             auto value = store.get<ArgType>(section, key);
-
-            if (value)
-                Func(key, *value);
+            Func(key, value ? *value : ArgType{});
         };
 
         handlers.push_back(std::move(subscription));
@@ -94,8 +92,7 @@ namespace vkShade
         subscription.reload = [instance, section, key](ConfigStore& store)
         {
             auto value = store.get<ArgType>(section, key);
-            if (value)
-                (instance->*Method)(key, *value);
+            (instance->*Method)(key, value ? *value : ArgType{});
         };
 
         handlers.push_back(std::move(subscription));

--- a/src/config/config_observer.inl
+++ b/src/config/config_observer.inl
@@ -112,6 +112,11 @@ namespace vkShade
         if (it != m_subscribers.end())
         {
             auto& handlers = it->second;
+
+            for (auto& sub : handlers)
+                if (sub.function == pFunction && sub.instance == nullptr)
+                    *sub.alive = false;
+
             handlers.erase(std::remove_if(handlers.begin(), handlers.end(),
                 [pFunction](const Subscription& sub)
                 {
@@ -145,6 +150,11 @@ namespace vkShade
         if (it != m_subscribers.end())
         {
             auto& handlers = it->second;
+
+            for (auto& sub : handlers)
+                if (sub.function == pMethod && sub.instance == instance)
+                    *sub.alive = false;
+
             handlers.erase(std::remove_if(handlers.begin(), handlers.end(),
                 [pMethod, instance](const Subscription& sub)
                 {


### PR DESCRIPTION
Two related bugs in ConfigObserver's notification path.

1. A bug fix was recently made to have `notify_all()` snapshot subscriptions before invoking them. This introduced another bug where a callback that destroys another subscriber mid-loop (e.g. resetting the effects list) left a dangling entry in the snapshot, causing a use-after-free. Fixed with a shared liveness flag that the snapshot checks before calling through.

2. `reload()` silently no-op'd on a failed lookup/parse, so subscribers were never told a key had been removed (e.g. deleting all shaders left them loaded because `on_shaders_changed()` never fired). Now calls through with a default-constructed value on failure.

Config appears to handle clears and callbacks correctly in all situations again.