### PR TITLE
fix(input): observe Xlib wheel without core events

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
             gcc \
             g++ \
             libx11-dev \
+            libxi-dev \
             libxcb1-dev \
             libwayland-dev \
             wayland-protocols \

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -22,7 +22,7 @@ vkShade provides a full-featured and easy to use build system, which will
 Before building, you will need:
 
 - GCC >= 12
-- X11 development files (`libx11`, `libxcb`)
+- X11 development files (`libx11`, `libxcb`, `libxi`)
 - Wayland development files (`wayland-client`)
 - xkbcommon development files (`libxkbcommon`)
 - SPIR-V Headers

--- a/src/input/input_backend_xlib.cpp
+++ b/src/input/input_backend_xlib.cpp
@@ -3,6 +3,8 @@
 #include <cstring>
 
 #include "core/logger.hpp"
+#include <X11/extensions/XInput2.h>
+#include <X11/Xatom.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/keysym.h>
@@ -21,12 +23,37 @@ vkShade::InputBackendXlib::InputBackendXlib(Display* display, Window window)
     // Initialize previous key states
     std::memset(m_previousKeymap, 0, sizeof(m_previousKeymap));
 
-    // Observe wheel button events without consuming the application's queue.
+    // Observe raw wheel button events without selecting exclusive core button
+    // events from the application's window.
     m_wheelDisplay = XOpenDisplay(DisplayString(m_display));
     if (m_wheelDisplay)
     {
-        XSelectInput(m_wheelDisplay, m_window, ButtonPressMask | ButtonReleaseMask);
-        XFlush(m_wheelDisplay);
+        m_topLevelWindow = get_top_level_window(m_wheelDisplay, m_window);
+        int event = 0;
+        int error = 0;
+        int major = 2;
+        int minor = 0;
+        const bool xi2Available = XQueryExtension(m_wheelDisplay, "XInputExtension",
+            &m_wheelXiOpcode, &event, &error) && XIQueryVersion(m_wheelDisplay, &major, &minor) == Success;
+
+        if (xi2Available)
+        {
+            unsigned char mask[XIMaskLen(XI_RawButtonPress)] {};
+            XISetMask(mask, XI_RawButtonPress);
+            XIEventMask eventMask {
+                .deviceid = XIAllMasterDevices,
+                .mask_len = static_cast<int>(sizeof(mask)),
+                .mask = mask,
+            };
+            XISelectEvents(m_wheelDisplay, DefaultRootWindow(m_wheelDisplay), &eventMask, 1);
+            XFlush(m_wheelDisplay);
+        }
+        else
+        {
+            Logger::warn("[Xlib] XInput2 is unavailable for mouse wheel input");
+            XCloseDisplay(m_wheelDisplay);
+            m_wheelDisplay = nullptr;
+        }
     }
     else
     {
@@ -73,18 +100,29 @@ void vkShade::InputBackendXlib::process_events()
         {
             XEvent event {};
             XNextEvent(m_wheelDisplay, &event);
-            if (event.type == ButtonPress
-                && event.xbutton.button >= Button4 && event.xbutton.button <= 7)
+            if (event.type != GenericEvent
+                || event.xcookie.extension != m_wheelXiOpcode
+                || event.xcookie.evtype != XI_RawButtonPress
+                || !XGetEventData(m_wheelDisplay, &event.xcookie))
+                continue;
+
+            const auto* rawEvent = static_cast<XIRawEvent*>(event.xcookie.data);
+            const int button = rawEvent->detail;
+            XFreeEventData(m_wheelDisplay, &event.xcookie);
+
+            if (button >= Button4 && button <= 7
+                && is_window_active(m_wheelDisplay)
+                && is_pointer_inside_window(m_wheelDisplay))
             {
-                if (event.xbutton.button <= Button5)
+                if (button <= Button5)
                 {
                     handle_mouse_wheel_event(
-                        0.0f, event.xbutton.button == Button4 ? 1.0f : -1.0f);
+                        0.0f, button == Button4 ? 1.0f : -1.0f);
                 }
                 else
                 {
                     handle_mouse_wheel_event(
-                        event.xbutton.button == 6 ? 1.0f : -1.0f, 0.0f);
+                        button == 6 ? 1.0f : -1.0f, 0.0f);
                 }
             }
         }
@@ -92,6 +130,81 @@ void vkShade::InputBackendXlib::process_events()
 
     // Query mouse state
     query_mouse_state();
+}
+
+Window vkShade::InputBackendXlib::get_top_level_window(Display* display, Window window)
+{
+    // Focus properties may identify a Wine child or window-manager frame, so comparisons use top-level identities.
+    Window root = None;
+    Window parent = None;
+    Window* children = nullptr;
+    unsigned int childCount = 0;
+    Window current = window;
+
+    while (XQueryTree(display, current, &root, &parent, &children, &childCount))
+    {
+        if (children)
+            XFree(children);
+        if (parent == None || parent == root)
+            return current;
+        current = parent;
+    }
+    return window;
+}
+
+bool vkShade::InputBackendXlib::is_window_active(Display* display)
+{
+    // Root-window XI2 events are shared across X11 clients, so forward them only while this surface owns focus.
+    Window focusWindow = None;
+    int revertTo = RevertToNone;
+    XGetInputFocus(display, &focusWindow, &revertTo);
+    if (focusWindow == None || focusWindow == PointerRoot
+        || get_top_level_window(display, focusWindow) != m_topLevelWindow)
+        return false;
+
+    const Atom activeWindowAtom = XInternAtom(display, "_NET_ACTIVE_WINDOW", True);
+    if (activeWindowAtom == None)
+        return true;
+
+    Atom actualType = None;
+    int actualFormat = 0;
+    unsigned long itemCount = 0;
+    unsigned long remaining = 0;
+    unsigned char* data = nullptr;
+    const int result = XGetWindowProperty(
+        display, DefaultRootWindow(display), activeWindowAtom,
+        0, 1, False, XA_WINDOW, &actualType, &actualFormat,
+        &itemCount, &remaining, &data);
+    Window activeWindow = None;
+    if (result == Success && actualType == XA_WINDOW && actualFormat == 32 && itemCount == 1)
+        activeWindow = *reinterpret_cast<Window*>(data);
+    if (data)
+        XFree(data);
+
+    return activeWindow == None
+        || get_top_level_window(display, activeWindow) == m_topLevelWindow;
+}
+
+bool vkShade::InputBackendXlib::is_pointer_inside_window(Display* display)
+{
+    // Keyboard focus may remain here after the pointer leaves, but the global XI2 observer continues receiving events.
+    XWindowAttributes attributes {};
+    if (!XGetWindowAttributes(display, m_window, &attributes))
+        return false;
+
+    Window root = None;
+    Window child = None;
+    int rootX = 0;
+    int rootY = 0;
+    int windowX = 0;
+    int windowY = 0;
+    unsigned int mask = 0;
+    if (!XQueryPointer(display, m_window, &root, &child,
+                       &rootX, &rootY, &windowX, &windowY, &mask))
+        return false;
+
+    return windowX >= 0 && windowY >= 0
+        && windowX < attributes.width && windowY < attributes.height;
 }
 
 void vkShade::InputBackendXlib::handle_key_event(uint32_t keyCode, bool pressed)

--- a/src/input/input_backend_xlib.hpp
+++ b/src/input/input_backend_xlib.hpp
@@ -18,7 +18,9 @@ namespace vkShade
     private:
         Display* m_display;
         Display* m_wheelDisplay {nullptr};
+        int      m_wheelXiOpcode {0};
         Window   m_window;
+        Window   m_topLevelWindow {0};
         char     m_previousKeymap[32];  // Track previous keyboard state
 
         // Track previous mouse state
@@ -30,5 +32,8 @@ namespace vkShade
         void handle_key_event(uint32_t keyCode, bool pressed);
         void query_mouse_state();
         void update_modifiers(unsigned int state);
+        bool is_window_active(Display* display);
+        bool is_pointer_inside_window(Display* display);
+        static Window get_top_level_window(Display* display, Window window);
     };
 } // namespace vkShade

--- a/src/input/meson.build
+++ b/src/input/meson.build
@@ -16,6 +16,7 @@ libinput_library = static_library(
     wayland_client,
     x11,
     xcb,
+    xi,
     xkbcommon,
   ],
   include_directories : vkShade_include_path

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,6 +22,7 @@ wayland_client = dependency('wayland-client')
 xkbcommon = dependency('xkbcommon')
 xcb = dependency('xcb', required: false)
 x11 = dependency('x11')
+xi = dependency('xi')
 
 subdir('platform')
 subdir('config')


### PR DESCRIPTION
Replace the secondary Xlib connection's core button-event selection with an XI2 raw-button observer on the root window.

The observer:

- preserves vertical and horizontal mouse-wheel input;
- filters events to the active game window and pointer location;
- no longer claims the application's exclusive core `ButtonPressMask`;
- adds the required `libxi` build and CI dependency.

Core `ButtonPressMask` selection is exclusive to one X11 client per window. Selecting it through vkShade's secondary display connection can therefore prevent Wine from receiving mouse clicks, even when the vkShade overlay has never been opened.

This was independently reproduced with Hogwarts Legacy and matches the failure reported in #114. Moving wheel observation to XI2 raw button events preserves GUI wheel input without taking ownership of the application's core button events.

## Testing

- Full project build
- All upstream unit tests
- Hogwarts Legacy:
  - game receives physical clicks while the overlay is closed;
  - overlay receives wheel input;
  - no click-through while the overlay is open;
  - game clicks resume after closing the overlay.
- Euro Truck Simulator 2:
  - vertical and horizontal wheel input;
  - no click-through while the overlay is open;
  - game input restored after closing the overlay.

Closes #114