### PR TITLE
fix(runtime): increase render fence timeout to 10 seconds

### DIFF
--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -16,10 +16,6 @@
 #include "vk/macros.hpp"
 #include "reshade_uniforms.hpp"
 
-// Give the layer's render submission up to 1 second to complete. A timeout
-//  indicates an abnormal GPU condition, so we will abort rather than hang.
-constexpr uint64_t FENCE_TIMEOUT_NS = 1'000'000'000;
-
 vkShade::Runtime::Runtime(VulkanDevice& device, VkSwapchainKHR swapchain, VkSwapchainCreateInfoKHR swapchainInfo)
     : VulkanObject(device)
 {

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -34,6 +34,10 @@ namespace vkShade
     private:
         using Clock = std::chrono::steady_clock;
 
+        // Give the layer's render submission up to 10 seconds to complete. A timeout
+        //  indicates an abnormal condition, so we'll abort rather than hang.
+        static constexpr uint64_t FENCE_TIMEOUT_NS = 10'000'000'000;
+
         // Swapchain resources
         VkSwapchainKHR m_swapchain;
         VkFormat m_format;


### PR DESCRIPTION
The render fence acts as vkShade's watchdog, and the layer will abort if the timeout is exceeded. Increase the timeout from 1 second to 10 seconds, to avoid aborting prematurely in cases of GPU contention.